### PR TITLE
Исправление закрытия шлюзов без питания

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -258,8 +258,10 @@ public sealed partial class DoorComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool CanPry = true;
 
+    // DS14-airlocks-closing-fix-start
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
     public bool IsBeingPried;
+    // DS14-airlocks-closing-fix-end
 
     [DataField]
     public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -34,21 +34,25 @@ public abstract class SharedAirlockSystem : EntitySystem
         if (args.Cancelled)
             return;
 
+        // DS14-airlocks-closing-fix-start
         if (!TryComp(uid, out DoorComponent? door))
             return;
+        // DS14-airlocks-closing-fix-end
 
         if (!airlock.Safety)
             args.PerformCollisionCheck = false;
 
+        // DS14-airlocks-closing-fix-start
         // If the door is pried to close (closed with a crowbar), always check for collisions,
         // because there is not enough force to crush someone with your hands
         if (door.IsBeingPried)
             args.PerformCollisionCheck = true;
+        // DS14-airlocks-closing-fix-end
 
         // only block based on bolts / power status when initially closing the door, not when its already
         // mid-transition. Particularly relevant for when the door was pried-closed with a crowbar, which bypasses
         // the initial power-check.
-        if (!door.Partial && !CanChangeState(uid, airlock, door.IsBeingPried))
+        if (!door.Partial && !CanChangeState(uid, airlock, door.IsBeingPried)) // DS14-airlocks-closing-fix
         {
             args.Cancel();
         }
@@ -85,12 +89,14 @@ public abstract class SharedAirlockSystem : EntitySystem
 
     private void OnBeforeDoorOpened(EntityUid uid, AirlockComponent component, BeforeDoorOpenedEvent args)
     {
+        // DS14-airlocks-closing-fix-start
         if (TryComp(uid, out DoorComponent? door)
             && !door.Partial
             && !CanChangeState(uid, component, door.IsBeingPried))
         {
             args.Cancel();
         }
+        // DS14-airlocks-closing-fix-end
     }
 
     private void OnBeforeDoorDenied(EntityUid uid, AirlockComponent component, BeforeDoorDeniedEvent args)
@@ -183,8 +189,8 @@ public abstract class SharedAirlockSystem : EntitySystem
         component.Safety = value;
     }
 
-    public bool CanChangeState(EntityUid uid, AirlockComponent component, bool isBeingPried = false)
+    public bool CanChangeState(EntityUid uid, AirlockComponent component, bool isBeingPried = false) // DS14-airlocks-closing-fix
     {
-        return component.Powered && !DoorSystem.IsBolted(uid) || !component.Powered && isBeingPried ;
+        return component.Powered && !DoorSystem.IsBolted(uid) || !component.Powered && isBeingPried ; // DS14-airlocks-closing-fix
     }
 }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -231,14 +231,15 @@ public abstract partial class SharedDoorSystem : EntitySystem
     {
         if (door.State == DoorState.Closed)
         {
+            door.IsBeingPried = true;
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} open");
-            StartOpening(uid, door, args.User, true);
+            TryOpen(uid, door, args.User, true);
         }
         else if (door.State == DoorState.Open)
         {
             door.IsBeingPried = true;
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} closed");
-            StartClosing(uid, door, args.User, true);
+            TryClose(uid, door, args.User, true);
         }
     }
 
@@ -383,6 +384,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         SetCollidable(uid, false, door);
         door.Partial = true;
+        door.IsBeingPried = false;
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         _activeDoors.Add((uid, door));
         Dirty(uid, door);

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -231,15 +231,15 @@ public abstract partial class SharedDoorSystem : EntitySystem
     {
         if (door.State == DoorState.Closed)
         {
-            door.IsBeingPried = true;
+            door.IsBeingPried = true; // DS14-airlocks-closing-fix
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} open");
-            TryOpen(uid, door, args.User, true);
+            TryOpen(uid, door, args.User, true); // DS14-airlocks-closing-fix
         }
         else if (door.State == DoorState.Open)
         {
-            door.IsBeingPried = true;
+            door.IsBeingPried = true; // DS14-airlocks-closing-fix
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} closed");
-            TryClose(uid, door, args.User, true);
+            TryClose(uid, door, args.User, true); // DS14-airlocks-closing-fix
         }
     }
 
@@ -384,7 +384,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         SetCollidable(uid, false, door);
         door.Partial = true;
-        door.IsBeingPried = false;
+        door.IsBeingPried = false; // DS14-airlocks-closing-fix
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         _activeDoors.Add((uid, door));
         Dirty(uid, door);
@@ -480,13 +480,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;
             AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
-            door.IsBeingPried = false;
+            door.IsBeingPried = false; // DS14-airlocks-closing-fix
             Dirty(uid, door);
             return false;
         }
 
         door.Partial = true;
-        door.IsBeingPried = false;
+        door.IsBeingPried = false; // DS14-airlocks-closing-fix
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили? -->
Исправлен баг, что нельзя закрыть шлюз без питания (ломом или руками).

## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. -->

Баг, что нельзя закрыть шлюз без питания:

https://github.com/space-wizards/space-station-14/issues/33795

https://discord.com/channels/1030160796401016883/1333467066019090513/1333467066019090513

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

Взят этот PR https://github.com/space-wizards/space-station-14/pull/33968, в котором в `DoorComponent` добавлено поле `IsBeingPried` (подвергается ли дверь "силовому" воздействию) и проверки, что состояние шлюза можно изменить, когда нет питания и дверь изменяют силой (`!component.Powered && isBeingPried`).

От себя: проверил, пофиксил ([мои изменения](https://github.com/dakone22/space-station-14-fobos/compare/194f8eb42610a2ec3a9443d039510a078b441039...fb6bc8da74d4217729fa23507f81979131f362ef)) баг, что нет проверок на коллизии (шлюз при силовом закрытии "давил")

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

![fixed_airlock_closing](https://github.com/user-attachments/assets/421067c1-ed49-446c-996d-17ef509cb5f0)

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

- Добавлено поле `IsBeingPried` в `DoorComponent`
- Изменена логика:
  - `SharedDoorSystem::OnAfterPry`
  - `SharedAirlockSystem::CanChangeState`
  - `SharedAirlockSystem::OnBeforeDoorClosed`
  - `SharedAirlockSystem::OnBeforeDoorOpened`

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Исправлено закрытие шлюзов без питания