### PR TITLE
Рокировка Матебы и Кольта в лодаутах

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Entities/Other/ertloadouts.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Other/ertloadouts.yml
@@ -151,7 +151,7 @@
     state: red
   - type: ThiefUndeterminedBackpack
     possibleSets:
-    - MatebaSet
+    - N1984Set
     - LaserGunSet
   - type: ActivatableUI
     key: enum.ThiefBackpackUIKey.Key
@@ -193,7 +193,7 @@
     state: gamma
   - type: ThiefUndeterminedBackpack
     possibleSets:
-    - N1984Set
+    - MatebaSet
     - PulsePistolSet
     - AdvancedLaserSet
   - type: ActivatableUI
@@ -445,6 +445,7 @@
   - SpeedLoaderMagnum
   - SpeedLoaderMagnum
   - MagazineBoxMagnum
+  - MagazineBoxMagnum
 
 - type: thiefBackpackSet
   id: N1984Set
@@ -458,7 +459,6 @@
   - MagazineMagnum
   - MagazineMagnum
   - MagazineMagnum
-  - MagazineBoxMagnum
   - MagazineBoxMagnum
 
 - type: thiefBackpackSet


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
Матеба и N1984 поменялись местами в лодаутах ОБР. Матеба теперь у Гаммы, N1984 у Красного.

## Почему / Зачем / Баланс
Попробовал сам, послушал мнения в предложении https://discord.com/channels/1030160796401016883/1340097111307456672/1340097111307456672. 
Точность Матебы - серьёзное преимущество перед N1984. Значит логически, она должна быть у отряда получше.

## Технические детали
Поменялись местами айди предметов в лодаутах.

## Медиа

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- tweak: Матеба и N1984 поменялись местами в лодаутах ОБР. Матеба перешла к Гамме, N1984 к Красному. https://discord.com/channels/1030160796401016883/1340097111307456672/1340097111307456672

