### PR TITLE
Убрана автозамена !! на OwO и тд

### DIFF
--- a/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
@@ -4,7 +4,6 @@ namespace Content.Server.Speech.EntitySystems
 {
     public sealed class OwOAccentSystem : EntitySystem
     {
-
         private static readonly IReadOnlyDictionary<string, string> SpecialWords = new Dictionary<string, string>()
         {
             { "you", "wu" },

--- a/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
@@ -7,10 +7,6 @@ namespace Content.Server.Speech.EntitySystems
     {
         [Dependency] private readonly IRobustRandom _random = default!;
 
-        private static readonly IReadOnlyList<string> Faces = new List<string>{
-            " (•`ω´•)", " ;;w;;", " owo", " UwU", " >w<", " ^w^"
-        }.AsReadOnly();
-
         private static readonly IReadOnlyDictionary<string, string> SpecialWords = new Dictionary<string, string>()
         {
             { "you", "wu" },
@@ -30,7 +26,7 @@ namespace Content.Server.Speech.EntitySystems
                 message = message.Replace(word, repl);
             }
 
-            return message.Replace("!!", _random.Pick(Faces))
+            return message
                 // Corvax-Localization-Start
                 .Replace("р", "в").Replace("Р", "В")
                 .Replace("л", "в").Replace("Л", "В")

--- a/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
@@ -1,11 +1,9 @@
 using Content.Server.Speech.Components;
-using Robust.Shared.Random;
 
 namespace Content.Server.Speech.EntitySystems
 {
     public sealed class OwOAccentSystem : EntitySystem
     {
-        [Dependency] private readonly IRobustRandom _random = default!;
 
         private static readonly IReadOnlyDictionary<string, string> SpecialWords = new Dictionary<string, string>()
         {


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
<!-- Что вы изменили? -->
Убрана автозамена !! на смайлики (OwO и тд.)

## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. -->
Неуместные смайлики в разговоре, при которых не возможно кричать. Реализация предложки https://discord.com/channels/1030160796401016883/1340586443277336596

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Просто убран лист смайликов и автозамена !! на них

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Нет

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

