### PR TITLE
Исправление закрытия шлюзов без питания (ещё раз)

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -258,6 +258,11 @@ public sealed partial class DoorComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool CanPry = true;
 
+    // DS14-airlocks-closing-fix-start
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsBeingPried;
+    // DS14-airlocks-closing-fix-end
+
     [DataField]
     public ProtoId<ToolQualityPrototype> PryingQuality = "Prying";
 

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -259,6 +259,16 @@ public sealed partial class DoorComponent : Component
     public bool CanPry = true;
 
     // DS14-airlocks-closing-fix-start
+    /// <summary>
+    /// Indicates whether the door is currently being pried (either open or closed).
+    /// </summary>
+    /// <remarks>
+    /// This flag is set to <c>true</c> after successful prying (here <see cref="SharedDoorSystem.OnAfterPry"/>) (e.g., using a crowbar) to temporarily bypass
+    /// normal access checks and modify collision behavior. When pried, the door system enforces collision checks
+    /// for safety and allows the door to transition between open and closed states regardless of standard access
+    /// restrictions. Once the prying operation is complete—typically when the door reaches a partially open or
+    /// closed state—the flag is reset to <c>false</c>, restoring the door's normal behavior.
+    /// </remarks>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
     public bool IsBeingPried;
     // DS14-airlocks-closing-fix-end

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -231,13 +231,15 @@ public abstract partial class SharedDoorSystem : EntitySystem
     {
         if (door.State == DoorState.Closed)
         {
+            door.IsBeingPried = true; // DS14-airlocks-closing-fix
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} open");
-            StartOpening(uid, door, args.User, true);
+            TryOpen(uid, door, args.User, true); // DS14-airlocks-closing-fix
         }
         else if (door.State == DoorState.Open)
         {
+            door.IsBeingPried = true; // DS14-airlocks-closing-fix
             _adminLog.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User)} pried {ToPrettyString(uid)} closed");
-            StartClosing(uid, door, args.User, true);
+            TryClose(uid, door, args.User, true); // DS14-airlocks-closing-fix
         }
     }
 
@@ -382,6 +384,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         SetCollidable(uid, false, door);
         door.Partial = true;
+        door.IsBeingPried = false; // DS14-airlocks-closing-fix
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         _activeDoors.Add((uid, door));
         Dirty(uid, door);
@@ -477,11 +480,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             door.NextStateChange = GameTiming.CurTime + door.OpenTimeTwo;
             door.State = DoorState.Open;
             AppearanceSystem.SetData(uid, DoorVisuals.State, DoorState.Open);
+            door.IsBeingPried = false; // DS14-airlocks-closing-fix
             Dirty(uid, door);
             return false;
         }
 
         door.Partial = true;
+        door.IsBeingPried = false; // DS14-airlocks-closing-fix
         SetCollidable(uid, true, door, physics);
         door.NextStateChange = GameTiming.CurTime + door.CloseTimeTwo;
         Dirty(uid, door);

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -335,7 +335,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (ev.Cancelled)
             return false;
 
-        if (!HasAccess(uid, user, door))
+        if (!HasAccess(uid, user, door) && !door.IsBeingPried) // DS14-airlocks-closing-fix
         {
             if (!quiet)
                 Deny(uid, door, user, predicted: true);
@@ -442,7 +442,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (ev.Cancelled)
             return false;
 
-        if (!HasAccess(uid, user, door))
+        if (!HasAccess(uid, user, door) && !door.IsBeingPried)
             return false;
 
         return !ev.PerformCollisionCheck || !GetColliding(uid).Any();

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -445,7 +445,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (ev.Cancelled)
             return false;
 
-        if (!HasAccess(uid, user, door) && !door.IsBeingPried)
+        if (!HasAccess(uid, user, door) && !door.IsBeingPried) // DS14-airlocks-closing-fix
             return false;
 
         return !ev.PerformCollisionCheck || !GetColliding(uid).Any();

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -55,9 +55,13 @@ public abstract class SharedFirelockSystem : EntitySystem
         // Give the Door remote the ability to force a firelock open even if it is holding back dangerous gas
         var overrideAccess = (args.User != null) && _accessReaderSystem.IsAllowed(args.User.Value, uid);
 
-        if (!component.Powered || (!overrideAccess && component.IsLocked))
+        // DS14-airlocks-closing-fix-start
+        if (!TryComp(uid, out DoorComponent? door))
+            return;
+        // DS14-airlocks-closing-fix-end
+        if (!door.IsBeingPried && (!component.Powered || (!overrideAccess && component.IsLocked))) // DS14-airlocks-closing-fix
             args.Cancel();
-        else if (args.User != null)
+        else if (component.IsLocked && args.User != null) // DS14-airlocks-closing-fix
             WarnPlayer((uid, component), args.User.Value);
     }
 


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили? -->
Исправлен баг, что нельзя закрыть шлюз без питания (ломом или руками).

## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. -->

Баг, что нельзя закрыть шлюз без питания:

https://github.com/space-wizards/space-station-14/issues/33795

https://discord.com/channels/1030160796401016883/1333467066019090513/1333467066019090513

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

Взят этот PR https://github.com/space-wizards/space-station-14/pull/33968, в котором в `DoorComponent` добавлено поле `IsBeingPried` (подвергается ли дверь "силовому" воздействию) и проверки, что состояние шлюза можно изменить, когда нет питания и дверь изменяют силой (`!component.Powered && isBeingPried`).

От себя: проверил, пофиксил ([мои изменения](https://github.com/dakone22/space-station-14-fobos/compare/194f8eb42610a2ec3a9443d039510a078b441039...fb6bc8da74d4217729fa23507f81979131f362ef)) баг, что нет проверок на коллизии (шлюз при силовом закрытии "давил"), убрал проверки на доступы при "силовом" воздействии.

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

<table>
  <tr>
    <td>
<img src="https://github.com/user-attachments/assets/421067c1-ed49-446c-996d-17ef509cb5f0" alt="fixed_airlock_closing" >
    </td>
    <td>
<img src="https://github.com/user-attachments/assets/448c5662-4469-49b3-b562-5222ff29afdc" alt="fixed_airlock_closing_powered" >
    </td>
   </tr> 
  <tr>
    <td>
<img src="https://github.com/user-attachments/assets/d550602c-9fb6-446c-9143-005bc23d6439" alt="fixed_locked_firelock" >
    </td>
    <td>
<img src="https://github.com/user-attachments/assets/73a7112a-c7d2-4067-89e6-27ae112a3f42" alt="fixed_airlock_closing_unpowered" >
    </td>
   </tr> 
</table>


## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

- Добавлено поле `IsBeingPried` в `DoorComponent`
- Изменена логика:
  - `SharedDoorSystem::OnAfterPry`
  - `SharedDoorSystem::CanOpen`
  - `SharedDoorSystem::CanClose`
  - `SharedAirlockSystem::CanChangeState`
  - `SharedAirlockSystem::OnBeforeDoorClosed`
  - `SharedAirlockSystem::OnBeforeDoorOpened`

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->

:cl:
- fix: Исправлено закрытие шлюзов без питания (ещё раз)

