### PR TITLE
Фикс отображения вещественной частоты канала в русской локализации

### DIFF
--- a/Resources/Locale/ru-RU/radio/components/encryption-key-component.ftl
+++ b/Resources/Locale/ru-RU/radio/components/encryption-key-component.ftl
@@ -5,5 +5,5 @@ encryption-keys-no-keys = В этом устройстве нет ключей �
 encryption-keys-are-locked = Ячейка ключей шифрования заблокирована.
 encryption-keys-panel-locked = Сначала откройте техническую панель.
 examine-encryption-channels-prefix = Доступные частоты:
-examine-encryption-channel = [color={ $color }]{ $key } для канала { $id } (частота { $freq })[/color]
+examine-encryption-channel = [color={ $color }]{ $key } для канала { $id } ({NATURALFIXED($freq, 1)})[/color]
 examine-encryption-default-channel = Каналом по умолчанию является [color={ $color }]{ $channel }[/color].


### PR DESCRIPTION
## Описание PR
Фикс отображения вещественной частоты канала в русской локализации

## Почему / Зачем / Баланс
Сейчас так:
![image](https://github.com/user-attachments/assets/664f2784-9a5f-4c75-8fdb-653d129461e2)
Как должно быть (апстрим https://github.com/space-wizards/space-station-14/pull/35046):
<img src="https://github.com/user-attachments/assets/8f03eb80-fbd9-416c-8fcc-1fffc3a7b063" height="375">

## Технические детали
```
examine-encryption-channel = [color={ $color }]{ $key } для канала { $id } ({NATURALFIXED($freq, 1)})[/color]
```
В соответствии с локализацией берётся десятичный знак. Для русского берётся `,`. Если не подходит, можно будет переделать или добавить свою функцию вместо `NATURALFIXED`.

## Медиа
Теперь так:
![Screenshot 2025-02-21 024715](https://github.com/user-attachments/assets/70ef122e-8d4e-45ae-9e8c-3c14b934c801)

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Отображение вещественной частоты канала

