### PR TITLE
Добавление шаттла пиратов в пул случайных шаттлов

### DIFF
--- a/Resources/Locale/en-US/ss14-ru/prototypes/gamerules/unknown_shuttles.ftl
+++ b/Resources/Locale/en-US/ss14-ru/prototypes/gamerules/unknown_shuttles.ftl
@@ -38,3 +38,5 @@ ent-UnknownShuttleMicroshuttle = { ent-BaseUnknownShuttleRule }
     .desc = { ent-BaseUnknownShuttleRule.desc }
 ent-UnknownShuttleSpacebus = { ent-BaseUnknownShuttleRule }
     .desc = { ent-BaseUnknownShuttleRule.desc }
+ent-UnknownShuttlePirate = { ent-BaseUnknownShuttleRule }
+    .desc = { ent-BaseUnknownShuttleRule.desc }

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/gamerules/unknown_shuttles.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/gamerules/unknown_shuttles.ftl
@@ -38,3 +38,5 @@ ent-UnknownShuttleMicroshuttle = { ent-BaseUnknownShuttleRule }
     .desc = { ent-BaseUnknownShuttleRule.desc }
 ent-UnknownShuttleSpacebus = { ent-BaseUnknownShuttleRule }
     .desc = { ent-BaseUnknownShuttleRule.desc }
+ent-UnknownShuttlePirate = { ent-BaseUnknownShuttleRule }
+    .desc = { ent-BaseUnknownShuttleRule.desc }

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -20,6 +20,7 @@
     - id: UnknownShuttleMeatZone
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
+    - id: UnknownShuttlePirate
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -243,3 +244,11 @@
   - type: LoadMapRule
     preloadedGrid: Spacebus
 
+- type: entity
+  id: UnknownShuttlePirate
+  parent: BaseUnknownShuttleRule
+  components:
+  - type: StationEvent
+    startAnnouncement: null
+  - type: LoadMapRule
+    preloadedGrid: Pirate

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -20,7 +20,7 @@
     - id: UnknownShuttleMeatZone
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
-    - id: UnknownShuttlePirate
+    - id: UnknownShuttlePirate # DS14
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -243,6 +243,8 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Spacebus
+
+# DS14-start
 
 - type: entity
   id: UnknownShuttlePirate

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -98,3 +98,8 @@
   id: Spacebus
   path: /Maps/Shuttles/ShuttleEvent/spacebus.yml
   copies: 1
+
+- type: preloadedGrid
+  id: Pirate
+  path: /Maps/Shuttles/pirate.yml
+  copies: 1

--- a/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
+++ b/Resources/Prototypes/Shuttles/shuttle_incoming_event.yml
@@ -99,6 +99,8 @@
   path: /Maps/Shuttles/ShuttleEvent/spacebus.yml
   copies: 1
 
+# DS14-start
+
 - type: preloadedGrid
   id: Pirate
   path: /Maps/Shuttles/pirate.yml


### PR DESCRIPTION
## Описание PR
Добавил шаттл каперов в пул рандомных шаттлов как, например, странствующие шеф-повары или клоуны

## Почему / Зачем / Баланс
По предложке ([ссылка](https://discord.com/channels/1030160796401016883/1341439145926725733))

## Технические детали
В уже существующие файлы добавил новый путь, а так же локализацию. Так же сделал само появление шаттла безвучным, что, как по мне, будет лучше. Стоило ли добавлять комментарии вида `#DS14` к новым прототипам или надо переместить в папку DeadSpace/... ?

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
нема

**Список изменений**
:cl:
- add: Пираты возвращены как мидраунд антагонисты.
