### PR TITLE
Фикс кувшинов для напитков и ведра

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -85,6 +85,8 @@
   - type: PhysicalComposition
     materialComposition:
       Glass: 100
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   id: DrinkBottleVisualsOpenable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -241,6 +241,8 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/colabottle.rsi
   - type: Sealable
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]
@@ -417,6 +419,8 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space_mountain_wind_bottle.rsi
   - type: Sealable
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottlePlasticBaseFull]
@@ -436,6 +440,8 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/space-up_bottle.rsi
   - type: Sealable
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottleGlassBaseFull]
@@ -582,6 +588,8 @@
     tags:
     - Beer
     - DrinkBottle
+  - type: Item
+    size: Large # DS14
 
 - type: entity
   parent: [DrinkBottleVisualsAll, DrinkBottlePlasticBaseFull]
@@ -590,7 +598,7 @@
   description: A true dorf's drink of choice.
   components:
   - type: Item
-    size: Small
+    size: Normal # DS14
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -674,6 +682,8 @@
           Quantity: 150
   - type: Label
     currentLabel: reagent-name-soda-water
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   parent: DrinkWaterBottleFull
@@ -690,6 +700,8 @@
           Quantity: 150
   - type: Label
     currentLabel: reagent-name-tonic-water
+  - type: Item
+    size: Normal # DS14
 
 - type: entity
   parent: [DrinkBottleVisualsOpenable, DrinkBottleGlassBaseFull]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -780,10 +780,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: Sugar
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-sugar
@@ -797,10 +797,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: LemonLime
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-lemon-lime
@@ -831,10 +831,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: Ice
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-ice
@@ -848,10 +848,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: CoconutWater
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-coconut-water
@@ -865,10 +865,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: Coffee
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-coffee
@@ -882,10 +882,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: Tea
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-tea
@@ -899,10 +899,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: GreenTea
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-green-tea
@@ -916,10 +916,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: IcedTea
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-iced-tea
@@ -933,10 +933,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: DrGibb
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-dr-gibb
@@ -950,10 +950,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: RootBeer
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-root-beer
@@ -967,10 +967,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
         reagents:
         - ReagentId: JuiceWatermelon
-          Quantity: 200
+          Quantity: 200 # DS14
   - type: Drink
   - type: Label
     currentLabel: reagent-name-juice-watermelon
@@ -1001,5 +1001,5 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 200
+        maxVol: 200 # DS14
   - type: Drink

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_bottles.yml
@@ -22,7 +22,7 @@
     state: icon
     sprite: Objects/Consumable/Drinks/generic_jug.rsi # fallback to generic plastic jug
   - type: Item
-    size: Normal
+    size: Large # DS14
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -780,10 +780,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: Sugar
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-sugar
@@ -797,10 +797,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: LemonLime
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-lemon-lime
@@ -831,10 +831,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: Ice
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-ice
@@ -848,10 +848,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: CoconutWater
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-coconut-water
@@ -865,10 +865,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: Coffee
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-coffee
@@ -882,10 +882,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: Tea
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-tea
@@ -899,10 +899,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: GreenTea
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-green-tea
@@ -916,10 +916,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: IcedTea
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-iced-tea
@@ -933,10 +933,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: DrGibb
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-dr-gibb
@@ -950,10 +950,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: RootBeer
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-root-beer
@@ -967,10 +967,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300
+        maxVol: 200
         reagents:
         - ReagentId: JuiceWatermelon
-          Quantity: 300
+          Quantity: 200
   - type: Drink
   - type: Label
     currentLabel: reagent-name-juice-watermelon
@@ -1001,5 +1001,5 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 150
+        maxVol: 200
   - type: Drink

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -68,9 +68,10 @@
     materialComposition:
       Plastic: 50
   - type: DnaSubstanceTrace
-  - type: Damageable #DS14
+  # DS14-start
+  - type: Damageable
     damageContainer: Inorganic
-  - type: Destructible #DS14
+  - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
@@ -87,3 +88,4 @@
           ScrapBucket:
             min: 1
             max: 1
+  # DS14-end

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -68,3 +68,22 @@
     materialComposition:
       Plastic: 50
   - type: DnaSubstanceTrace
+  - type: Damageable #DS14
+    damageContainer: Inorganic
+  - type: Destructible #DS14
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 25
+      behaviors:
+      - !type:SpillBehavior { }
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          ScrapBucket:
+            min: 1
+            max: 1

--- a/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Drinks/cup_and_teapot.yml
+++ b/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Drinks/cup_and_teapot.yml
@@ -31,3 +31,5 @@
         maxVol: 100
   - type: Sprite
     sprite: Objects/Consumable/Drinks/teapot.rsi
+  - type: Item
+    size: Normal # DS14


### PR DESCRIPTION
## Описание PR
Изменён размер кувшинов для напитков - теперь они равны химическим, 2х4. Уменьшен объём некоторых кувшинов до стандартных 200 (300->200), но взамен увеличен объём пустого кувшина для напитков до 200 (150->200). Добавлена разрушаемость ведру - теперь оно не защищает содержимое от взрывов, ломается от нескольких ударов ломом (25 прочности) с характерным металлическим звуком, разливая содержимое и оставляя на своём месте сломанное ведро (мусор с обломков).

## Почему / Зачем / Баланс
После увеличения ведра для льда и шейкера, некоторые игроки стали использовать огромные (150-300!!!) кувшины для напитков, что занимают всего 2х2. Либо ведро, что имеет ёмкость 250 при размере 2х2, ещё и защищает от взрывов. Все эти недостатки были исправлены в угоду балансу и использованию менее популярных, профильных ёмкостей (криостазисная мензурка, например).

## Технические детали
Увеличен размер кувшинов до 2х4, ёмкость некоторых уменьшена до 200. Добавлена разрушаемость ведру.

## Медиа
![jug](https://github.com/user-attachments/assets/e52a9392-ee8e-4e46-9692-f8b8c22850ff)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Были изменены: \Prototypes\Entities\Objects\Consumable\Drinks\drinks_bottles.yml - изменён размер базового предмета, местами изменена максимальная ёмкость. \Prototypes\Entities\Objects\Tools\bucket.yml - добавлена разрушаемость предмету.

**Список изменений**
:cl:
- add: Добавлена разрушаемость ведру. Теперь оно не защищает содержимое от взрывов и может быть сломано.
- tweak: Изменён размер кувшинов для напитков (2х4), уменьшена ёмкость до 200. 
