### PR TITLE
Бафф демонов

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Demons/demons.yml
+++ b/Resources/Prototypes/_DeadSpace/Demons/demons.yml
@@ -43,8 +43,9 @@
   - type: Appearance
   - type: Bloodstream
     bloodReagent: DemonsBlood
-    bloodMaxVolume: 150
-    bloodlossThreshold: 0.4
+    bloodMaxVolume: 200
+    bloodlossThreshold: 0.3
+    bloodRefreshAmount: 2
   - type: CombatMode
   - type: MeleeWeapon
     altDisarm: false

--- a/Resources/Prototypes/_DeadSpace/Demons/demons.yml
+++ b/Resources/Prototypes/_DeadSpace/Demons/demons.yml
@@ -44,7 +44,7 @@
   - type: Bloodstream
     bloodReagent: DemonsBlood
     bloodMaxVolume: 200
-    bloodlossThreshold: 0.4
+    bloodlossThreshold: 0.3
     bloodRefreshAmount: 2
   - type: CombatMode
   - type: MeleeWeapon

--- a/Resources/Prototypes/_DeadSpace/Demons/demons.yml
+++ b/Resources/Prototypes/_DeadSpace/Demons/demons.yml
@@ -44,7 +44,7 @@
   - type: Bloodstream
     bloodReagent: DemonsBlood
     bloodMaxVolume: 200
-    bloodlossThreshold: 0.3
+    bloodlossThreshold: 0.4
     bloodRefreshAmount: 2
   - type: CombatMode
   - type: MeleeWeapon


### PR DESCRIPTION
## Описание PR
Небольшой бафф демонов, общее кол-во крови увиличено на 33 процента(150 --》200)
Добавлено пассивное восстановление крови по 2 единицы за каждое обновление кровотечения то бишь если за одно обновление ты вытекал на 8 единиц крови то теперь будешь на 2 единицы фиксированно меньше

## Почему / Зачем / Баланс
Что бы не так быстро вытекали от кровотёка. Ну и предложка.

## Технические детали
2 строки кода в паренте демонов

## Медиа
Не нуждается

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
нету.

**Список изменений**
:cl:
- add: Уменьшено кровотечение у демонов.