### PR TITLE
Лёгкое исправление инвентарей хэппи хонков

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -752,8 +752,8 @@
         orGroup: GiftPool
       - id: PersonalAI
         orGroup: GiftPool
-      - id: CrayonBox
-        orGroup: GiftPool
+      # - id: CrayonBox # DS14
+      #   orGroup: GiftPool
       - id: ToySword
         orGroup: GiftPool
       - id: RevolverCapGun

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -274,7 +274,7 @@
       prob: 0.10
       orGroup: Pizza
     - id: KnifePlastic
-
+  
 - type: entity
   name: pizza box
   parent: FoodBoxPizzaFilled
@@ -497,9 +497,9 @@
     sprite: Objects/Storage/Happyhonk/clown.rsi
     heldPrefix: box
   - type: Storage
-    maxItemSize: Normal # DS14
-    grid:
-    - 0,0,3,2 # DS14
+    maxItemSize: Normal
+    # grid: # DS14
+    # - 0,0,3,3
   - type: Tag
     tags:
     - Trash
@@ -622,6 +622,9 @@
   suffix: Toy Unsafe, Snacks
   name: syndicate snack box
   components:
+  # - type: Storage # DS14
+  #   grid:
+  #   - 0,0,5,2
   - type: StorageFill
     contents:
     # toy
@@ -652,14 +655,15 @@
       orGroup: Drink2Pool
     - id: DrinkColaCan
       orGroup: Drink2Pool
-    - id: DrinkColaCan
+    # - id: DrinkColaCan # DS14
+    #   amount: 2
     # food
-    - id: FoodSaladValid
-      prob: 0.05
-      amount: 2 # DS14
-      orGroup: FoodPool
+    # - id: FoodSaladValid # DS14
+    #   prob: 0.05
+    #   amount: 4
+    #   orGroup: FoodPool
     - id: FoodSnackSyndi
-      amount: 4
+      amount: 3 # DS14
       orGroup: FoodPool
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -497,7 +497,7 @@
     sprite: Objects/Storage/Happyhonk/clown.rsi
     heldPrefix: box
   - type: Storage
-    maxItemSize: Small # DS14
+    maxItemSize: Normal # DS14
     grid:
     - 0,0,3,2 # DS14
   - type: Tag
@@ -591,10 +591,6 @@
   description: A sus meal with a potentially explosive surprise.
   suffix: Toy Unsafe
   components:
-  - type: Storage
-    maxItemSize: Small # DS14
-    grid:
-    - 0,0,5,2
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box
@@ -657,11 +653,10 @@
     - id: DrinkColaCan
       orGroup: Drink2Pool
     - id: DrinkColaCan
-      amount: 2
     # food
     - id: FoodSaladValid
       prob: 0.05
-      amount: 4
+      amount: 2 # DS14
       orGroup: FoodPool
     - id: FoodSnackSyndi
       amount: 4

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -499,7 +499,7 @@
   - type: Storage
     maxItemSize: Small # DS14
     grid:
-    - 0,0,3,1 # DS14
+    - 0,0,3,2 # DS14
   - type: Tag
     tags:
     - Trash
@@ -592,9 +592,9 @@
   suffix: Toy Unsafe
   components:
   - type: Storage
-    maxItemSize: Small
+    maxItemSize: Small # DS14
     grid:
-    - 0,0,5,2
+    - 0,0,4,2 # DS14
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -274,7 +274,7 @@
       prob: 0.10
       orGroup: Pizza
     - id: KnifePlastic
-  
+
 - type: entity
   name: pizza box
   parent: FoodBoxPizzaFilled
@@ -497,9 +497,9 @@
     sprite: Objects/Storage/Happyhonk/clown.rsi
     heldPrefix: box
   - type: Storage
-    maxItemSize: Normal
+    maxItemSize: Small # DS14
     grid:
-    - 0,0,3,3
+    - 0,0,3,1 # DS14
   - type: Tag
     tags:
     - Trash
@@ -623,8 +623,9 @@
   name: syndicate snack box
   components:
   - type: Storage
+    maxItemSize: Small # DS14
     grid:
-    - 0,0,5,2
+    - 0,0,4,2 # DS14
   - type: StorageFill
     contents:
     # toy

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -591,6 +591,10 @@
   description: A sus meal with a potentially explosive surprise.
   suffix: Toy Unsafe
   components:
+  - type: Storage
+    maxItemSize: Small # DS14
+    grid:
+    - 0,0,4,2 # DS14
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box
@@ -622,10 +626,6 @@
   suffix: Toy Unsafe, Snacks
   name: syndicate snack box
   components:
-  - type: Storage
-    maxItemSize: Small # DS14
-    grid:
-    - 0,0,4,2 # DS14
   - type: StorageFill
     contents:
     # toy

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -661,10 +661,10 @@
     # food
     - id: FoodSaladValid
       prob: 0.05
-      amount: 3
+      amount: 2
       orGroup: FoodPool
     - id: FoodSnackSyndi
-      amount: 3
+      amount: 4
       orGroup: FoodPool
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -626,10 +626,6 @@
   suffix: Toy Unsafe, Snacks
   name: syndicate snack box
   components:
-  - type: Storage
-    maxItemSize: Small # DS14
-    grid:
-    - 0,0,4,2 # DS14
   - type: StorageFill
     contents:
     # toy
@@ -665,10 +661,10 @@
     # food
     - id: FoodSaladValid
       prob: 0.05
-      amount: 4
+      amount: 3
       orGroup: FoodPool
     - id: FoodSnackSyndi
-      amount: 4
+      amount: 3
       orGroup: FoodPool
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -594,7 +594,7 @@
   - type: Storage
     maxItemSize: Small # DS14
     grid:
-    - 0,0,4,2 # DS14
+    - 0,0,5,2
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -592,9 +592,9 @@
   suffix: Toy Unsafe
   components:
   - type: Storage
-    maxItemSize: Small # DS14
+    maxItemSize: Small
     grid:
-    - 0,0,4,2 # DS14
+    - 0,0,2,2
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -594,7 +594,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,2,2
+    - 0,0,5,2
   - type: Sprite
     sprite: Objects/Storage/Happyhonk/nukie.rsi
     state: box
@@ -661,7 +661,7 @@
     # food
     - id: FoodSaladValid
       prob: 0.05
-      amount: 2
+      amount: 4
       orGroup: FoodPool
     - id: FoodSnackSyndi
       amount: 4

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -626,6 +626,10 @@
   suffix: Toy Unsafe, Snacks
   name: syndicate snack box
   components:
+  - type: Storage
+    maxItemSize: Small # DS14
+    grid:
+    - 0,0,4,2 # DS14
   - type: StorageFill
     contents:
     # toy


### PR DESCRIPTION
## Описание PR
Исправлен размер инвентаря хэппи хонков (2х4) и максимально допустимый размер предмета внутри. Повышен размер обычных нюка-хонков, теперь они равны заполненным едой (3Х5)

## Почему / Зачем / Баланс
Зачастую хэппи хонки используются как дополнительные 16 слотов инвентаря, при этом занимают они всего 6 и стоят 50 копеек. Отныне они будут использоваться по назначению - поварами, а не ОСЩ для хранения магазинов к дрозду

## Технические детали
Изменён файл \Prototypes\Entities\Objects\Consumable\Food\Containers\box.yml

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Критических изменений нет, кроме ограничения по размеру предмета внутри (Normal->Small), а так же уменьшения размера внутреннего хранилища

**Список изменений**
:cl:
- tweak: Изменена вместимость хэппи хонков - теперь она равна обычной аптечке (2х4). Все нюка-хонки имеют повышенный размер хранилища.

