### PR TITLE
Значок юридического департамента юристам

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -115,7 +115,7 @@
   id: JobLawyer
   groups:
   - GroupTankHarness
-  # - LawyerNeck
+  - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
   - Glasses


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
Это невероятно, но в этом pr-e вернул значок юристам в стартовое снаряжение (он и был, просто закомментирован)

## Почему / Зачем / Баланс
По предложке [ссылка](https://discord.com/channels/1030160796401016883/1342934827707404338)

## Технические детали
Убрал комментарий в стартовом снаряжении юриста

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
нема

**Список изменений**
:cl:
- add: Юристы вновь могут выбрать значок юридического департамента в стартовом снаряжении.
