### PR TITLE
Пауки ужаса

### DIFF
--- a/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
+++ b/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
@@ -4,5 +4,8 @@ namespace Content.Server.DeadSpace.Abilities.Felinid
     public sealed partial class HairballComponent : Component
     {
         public string SolutionName = "hairball";
+
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public float VomitChance = 0.2f;
     }
 }

--- a/Content.Server/DeadSpace/Drug/Components/DrugTestStickComponent.cs
+++ b/Content.Server/DeadSpace/Drug/Components/DrugTestStickComponent.cs
@@ -1,0 +1,28 @@
+
+namespace Content.Server.DeadSpace.Drug.Components;
+
+[RegisterComponent]
+public sealed partial class DrugTestStickComponent : Component
+{
+    [DataField("dna"), ViewVariables(VVAccess.ReadOnly)]
+    public string DNA = String.Empty;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int DependencyLevel = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float AddictionLevel = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Tolerance = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float WithdrawalLevel = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ThresholdTime = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsUsed = false;
+
+}

--- a/Content.Server/DeadSpace/Drug/Components/InstantDrugAddicationComponent.cs
+++ b/Content.Server/DeadSpace/Drug/Components/InstantDrugAddicationComponent.cs
@@ -1,0 +1,89 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared.Damage;
+using Robust.Shared.Audio;
+
+namespace Content.Server.DeadSpace.Drug.Components;
+
+[RegisterComponent]
+public sealed partial class InstantDrugAddicationComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int DependencyLevel = 1;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float AddictionLevel = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Tolerance = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float WithdrawalLevel = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float EffectStrengthModify = 1;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float WithdrawalRate = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float MaxWithdrawalLvl = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public float StaminaMultiply = 0.5f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float TimeLastAppointment = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public float SomeThresholdTime = 0;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public float StandartTemperature = 0;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    [DataField("updateDuration", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan UpdateDuration = TimeSpan.FromSeconds(1);
+
+    [DataField("timeUtilUpdate", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan TimeUtilUpdate = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    [DataField("sendMessageDuration", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan SendMessageDuration = TimeSpan.FromSeconds(5);
+
+    [DataField("timeUtilSendMessage", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan TimeUtilSendMessage = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    [DataField("changeAddictionDuration", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan ChangeAddictionDuration = TimeSpan.FromSeconds(30);
+
+    [DataField("timeUtilChangeAddiction", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan TimeUtilChangeAddiction = TimeSpan.Zero;
+
+    [DataField("durationOfActionWeakDrug", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan DurationOfActionWeakDrug = TimeSpan.Zero;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsTimeSendMessage = true;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsTakeWeakDrug = false;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsStaminaEdit = false;
+
+    [DataField("damage")]
+    public DamageSpecifier Damage = new()
+    {
+        DamageDict = new()
+        {
+            { "Asphyxiation", 2.5 }
+        }
+    };
+
+    [DataField]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public SoundSpecifier? SoundHighEffect = new SoundPathSpecifier("/Audio/DeadSpace/Drug/high_effect.ogg");
+
+}

--- a/Content.Server/DeadSpace/Drug/DrugAddicationSystem.cs
+++ b/Content.Server/DeadSpace/Drug/DrugAddicationSystem.cs
@@ -1,0 +1,337 @@
+using Content.Server.DeadSpace.Drug.Components;
+using Robust.Shared.Timing;
+using Content.Shared.Jittering;
+using Content.Server.Speech.EntitySystems;
+using Content.Shared.Stunnable;
+using Content.Shared.Damage.Components;
+using Content.Shared.Popups;
+using Content.Server.Temperature.Systems;
+using Content.Server.Temperature.Components;
+using Content.Shared.Damage;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mobs.Systems;
+
+namespace Content.Server.DeadSpace.Drug;
+
+public sealed class DrugAddicationSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedJitteringSystem _sharedJittering = default!;
+    [Dependency] private readonly SlurredSystem _slurred = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly TemperatureSystem _temperature = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    public const float MinAddictionLevel = 1;
+    public const float MinTolerance = 0.01f;
+    public const float DefaultAddictionLevel = 6;
+    public const float DefaultTolerance = 0.03f;
+    public const float MaxAddictionLevel = 100;
+    public const float MaxTolerance = 1;
+    public const float MaxWithdrawalLevel = 100;
+    public const float MaxAddTemperature = 10;
+    public const float MaxWithdrawalRate = 5;
+    public const float BaseThresholdTime = 300;
+    public const int MaxDrugStr = 4;
+    public const bool EnableMaxAddication = false; // настройка зависимости addication от тяжести наркотика (addication не будет превышать значение для зависимости с уровнем тяежсти)
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InstantDrugAddicationComponent, ComponentInit>(OnComponentInit);
+        SubscribeLocalEvent<InstantDrugAddicationComponent, ComponentShutdown>(OnComponentShut);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<InstantDrugAddicationComponent>();
+        while (query.MoveNext(out var uid, out var component))
+        {
+            if (_gameTiming.CurTime > component.TimeUtilUpdate)
+            {
+                UpdateDrugAddication(uid, component);
+                component.TimeUtilUpdate = _gameTiming.CurTime + component.UpdateDuration;
+            }
+
+            if (!component.IsTimeSendMessage && _gameTiming.CurTime > component.TimeUtilSendMessage)
+                component.IsTimeSendMessage = true;
+
+        }
+    }
+
+    private void OnComponentInit(EntityUid uid, InstantDrugAddicationComponent component, ComponentInit args)
+    {
+        component.TimeUtilChangeAddiction = _gameTiming.CurTime + component.ChangeAddictionDuration;
+
+        component.Tolerance = DefaultTolerance;
+        component.AddictionLevel = DefaultAddictionLevel;
+        if (TryComp<TemperatureComponent>(uid, out var temperature))
+            component.StandartTemperature = temperature.CurrentTemperature;
+
+        if (TryComp<StaminaComponent>(uid, out var stamina) && component.IsStaminaEdit)
+            stamina.CritThreshold /= component.StaminaMultiply;
+    }
+
+    private void OnComponentShut(EntityUid uid, InstantDrugAddicationComponent component, ComponentShutdown args)
+    {
+        RemComp<SlowedDownComponent>(uid);
+    }
+
+    public void UpdateDrugAddication(EntityUid uid, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (_mobState.IsDead(uid))
+            return;
+
+        if (component.AddictionLevel < MinAddictionLevel && component.Tolerance < MinTolerance)
+            RemComp<InstantDrugAddicationComponent>(uid);
+
+        var time = component.UpdateDuration;
+        float seconds = (float)Math.Abs(time.TotalSeconds);
+
+        AddTimeLastAppointment(uid, seconds, component);
+
+        if (component.TimeLastAppointment > component.SomeThresholdTime)
+        {
+            // Вычисляем разницу времени с последнего приема
+            var timeSinceLastAppointment = component.TimeLastAppointment - component.SomeThresholdTime;
+
+            // Определяем прогрессию WithdrawalRate от 0 до MaxWithdrawalRate
+            // Clamp для ограничения значения между 0 и 1
+            float progress = Math.Clamp(timeSinceLastAppointment / component.SomeThresholdTime, 0, 1);
+
+            // Вычисляем новый WithdrawalRate с интерполяцией
+            component.WithdrawalRate = progress * MaxWithdrawalRate;
+
+            UpdateMaxWithdrawalLevel(uid, component);
+            UpdateWithdrawalLevel(uid, component);
+            RunEffects(uid, component);
+        }
+
+        if (_gameTiming.CurTime > component.TimeUtilChangeAddiction)
+        {
+            component.AddictionLevel = Math.Max(0, component.AddictionLevel - 0.5f);
+            component.Tolerance = Math.Max(0, component.Tolerance - 0.01f);
+            component.TimeUtilChangeAddiction = _gameTiming.CurTime + component.ChangeAddictionDuration;
+        }
+
+    }
+
+    public void AddAddictionLevel(EntityUid uid, float effectStrenght, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.AddictionLevel = Math.Min(MaxAddictionLevel, component.AddictionLevel + effectStrenght * (1 - component.Tolerance));
+
+        if (EnableMaxAddication)
+            component.AddictionLevel = Math.Min(MaxAddictionLevel * component.DependencyLevel / MaxDrugStr, component.AddictionLevel);
+    }
+
+    public void AddTolerance(EntityUid uid, float effectStrenght, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.Tolerance = Math.Min(MaxTolerance, component.Tolerance + effectStrenght);
+    }
+
+    public void TakeDrug(EntityUid uid, int drugStrenght, float addictionStrenght, float toleranceStrenght, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        drugStrenght = Math.Min(MaxDrugStr, drugStrenght);
+
+        if (component.DependencyLevel <= drugStrenght)
+        {
+            AddAddictionLevel(uid, addictionStrenght, component);
+            AddTolerance(uid, toleranceStrenght, component);
+            component.DependencyLevel = drugStrenght;
+            component.TimeLastAppointment = 0;
+            CalculateThresholdTime(component);
+        }
+        else if (!component.IsTakeWeakDrug && _gameTiming.CurTime > component.DurationOfActionWeakDrug)
+        {
+            var strenght = drugStrenght / MaxDrugStr;
+
+            AddAddictionLevel(uid, addictionStrenght * strenght, component);
+            AddTolerance(uid, toleranceStrenght * strenght, component);
+            float randomFactor = Random.Shared.Next(100, 300) * strenght;
+            AddTimeLastAppointment(uid, -randomFactor, component);
+            component.DurationOfActionWeakDrug = _gameTiming.CurTime + TimeSpan.FromSeconds(randomFactor);
+        }
+    }
+
+    public void AddTimeLastAppointment(EntityUid uid, float count, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.TimeLastAppointment += count;
+        component.TimeLastAppointment = Math.Max(0, component.TimeLastAppointment);
+    }
+
+    public void UpdateWithdrawalLevel(EntityUid uid, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.WithdrawalLevel = Math.Min(MaxWithdrawalLevel, component.WithdrawalLevel + component.WithdrawalRate);
+        component.WithdrawalLevel = Math.Min(component.MaxWithdrawalLvl, component.WithdrawalLevel);
+    }
+
+    public void UpdateMaxWithdrawalLevel(EntityUid uid, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        // Влияние зависимости: чем выше зависимость, тем выше MaxWithdrawalLvl
+        float addictionImpact = component.AddictionLevel / MaxAddictionLevel;
+
+        // Влияние толерантности: чем выше толерантность, тем меньше MaxWithdrawalLvl
+        float toleranceImpact = 1 - (component.Tolerance / MaxTolerance);
+
+        // Общий расчет MaxWithdrawalLvl
+        component.MaxWithdrawalLvl = Math.Min(
+            MaxWithdrawalLevel,
+            MaxWithdrawalLevel * addictionImpact * toleranceImpact);
+    }
+
+    public void RunEffects(EntityUid uid, InstantDrugAddicationComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (component.WithdrawalLevel >= 10 && component.WithdrawalLevel < 25)
+        {
+            if (component.IsTimeSendMessage)
+            {
+                _popup.PopupEntity(Loc.GetString("drug-addication-effects-low"), uid, uid);
+                component.TimeUtilSendMessage = _gameTiming.CurTime + component.SendMessageDuration;
+                component.IsTimeSendMessage = false;
+            }
+
+            LowEffects(uid, component);
+        } else if (component.WithdrawalLevel >= 25 && component.WithdrawalLevel < 50)
+        {
+            if (component.IsTimeSendMessage)
+            {
+                _popup.PopupEntity(Loc.GetString("drug-addication-effects-medium"), uid, uid);
+                component.TimeUtilSendMessage = _gameTiming.CurTime + component.SendMessageDuration;
+                component.IsTimeSendMessage = false;
+            }
+
+            MediumEffects(uid, component);
+        } else if (component.WithdrawalLevel >= 50 && component.WithdrawalLevel < 75)
+        {
+            if (component.IsTimeSendMessage)
+            {
+                _popup.PopupEntity(Loc.GetString("drug-addication-effects-medium-plus"), uid, uid);
+                component.TimeUtilSendMessage = _gameTiming.CurTime + component.SendMessageDuration;
+                component.IsTimeSendMessage = false;
+            }
+
+            MediumPlusEffects(uid, component);
+        } else if (component.WithdrawalLevel >= 75)
+        {
+            if (component.IsTimeSendMessage)
+            {
+                _popup.PopupEntity(Loc.GetString("drug-addication-effects-high"), uid, uid);
+                component.TimeUtilSendMessage = _gameTiming.CurTime + component.SendMessageDuration;
+                component.IsTimeSendMessage = false;
+            }
+
+            HighEffects(uid, component);
+        }
+        else
+        {
+            RemComp<SlowedDownComponent>(uid);
+
+            if (TryComp<StaminaComponent>(uid, out var stamina) && !component.IsStaminaEdit)
+            {
+                stamina.CritThreshold /= component.StaminaMultiply;
+                component.IsStaminaEdit = false;
+            }
+        }
+    }
+
+    private void HighEffects(EntityUid uid, InstantDrugAddicationComponent component)
+    {
+        MediumPlusEffects(uid, component);
+        _slurred.DoSlur(uid, TimeSpan.FromSeconds(1f) + component.UpdateDuration);
+        EnsureComp<SlowedDownComponent>(uid);
+        _damageable.TryChangeDamage(uid, component.Damage, true);
+
+        if (TryComp<MindContainerComponent>(uid, out var mind)
+        && TryComp<MindComponent>(mind.Mind, out var mindComp) && mindComp.Session != null)
+        {
+            Filter playerFilter = Filter.Empty().AddPlayer(mindComp.Session);
+            _audio.PlayGlobal(component.SoundHighEffect, playerFilter, false);
+        }
+    }
+
+    private void MediumPlusEffects(EntityUid uid, InstantDrugAddicationComponent component)
+    {
+        _sharedJittering.DoJitter(uid, component.UpdateDuration, true, 10f * component.EffectStrengthModify);
+        MediumEffects(uid, component);
+
+        if (!TryComp<TemperatureComponent>(uid, out var temperature))
+            return;
+
+        if (temperature.CurrentTemperature > MaxAddTemperature + component.StandartTemperature)
+            return;
+
+        _temperature.ChangeHeat(uid, 4000 * component.EffectStrengthModify, true, temperature);
+    }
+
+    private void MediumEffects(EntityUid uid, InstantDrugAddicationComponent component)
+    {
+        LowEffects(uid, component);
+
+        if (!TryComp<TemperatureComponent>(uid, out var temperature))
+            return;
+
+        if (temperature.CurrentTemperature > MaxAddTemperature + component.StandartTemperature)
+            return;
+
+        _temperature.ChangeHeat(uid, 4000 * component.EffectStrengthModify, true, temperature);
+    }
+
+    private void LowEffects(EntityUid uid, InstantDrugAddicationComponent component)
+    {
+        if (TryComp<StaminaComponent>(uid, out var stamina) && !component.IsStaminaEdit)
+        {
+            stamina.CritThreshold *= component.StaminaMultiply;
+            component.IsStaminaEdit = true;
+        }
+    }
+
+    public float CalculateThresholdTime(InstantDrugAddicationComponent component)
+    {
+        // Рассчитываем модификатор зависимости: чем выше зависимость, тем меньше thresholdTime
+        float addictionModifier = 1 - (component.AddictionLevel / MaxAddictionLevel);
+
+        // Рассчитываем модификатор толерантности: чем выше толерантность, тем больше времени до ломки
+        float toleranceModifier = 1 + (component.Tolerance / MaxTolerance);
+
+        // Генерируем случайное значение в диапазоне от -10 до +10 секунд для случайности
+        float randomFactor = Random.Shared.Next(-10, 11);
+
+        // Вычисляем итоговое значение времени
+        float thresholdTime = BaseThresholdTime * addictionModifier * toleranceModifier + randomFactor;
+
+        // Ограничиваем значение, чтобы не было слишком короткого или слишком длинного времени
+        component.SomeThresholdTime = Math.Clamp(thresholdTime, 300, 600);
+
+        return component.SomeThresholdTime; // от 5 минут до 10 минут
+    }
+}

--- a/Content.Server/DeadSpace/Drug/DrugInitializeMachineSystem.cs
+++ b/Content.Server/DeadSpace/Drug/DrugInitializeMachineSystem.cs
@@ -1,0 +1,115 @@
+using Content.Server.DeadSpace.Drug.Components;
+using Robust.Shared.Timing;
+using Robust.Shared.Audio.Systems;
+using Content.Shared.DeadSpace.Drug.Components;
+using Content.Shared.Power;
+using Content.Shared.DeadSpace.Drug;
+using Content.Shared.Paper;
+using Robust.Shared.Containers;
+using System.Linq;
+
+namespace Content.Server.DeadSpace.Drug;
+
+public sealed class DrugInitializeMachineSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly PaperSystem _paperSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DrugInitializeMachineComponent, PowerChangedEvent>(OnPowerChanged);
+        SubscribeLocalEvent<DrugInitializeMachineComponent, StartDrugInitializeEvent>(OnStartInitialize);
+        SubscribeLocalEvent<DrugInitializeMachineComponent, MapInitEvent>(OnMapInit);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (!_gameTiming.IsFirstTimePredicted)
+            return;
+
+        var curTime = _gameTiming.CurTime;
+        var query = EntityQueryEnumerator<DrugInitializeMachineComponent>();
+        while (query.MoveNext(out var uid, out var component))
+        {
+            if (curTime >= component.RunningTime && component.IsRunning)
+                Running(uid, component);
+        }
+    }
+
+    protected void OnMapInit(EntityUid uid, DrugInitializeMachineComponent component, MapInitEvent args)
+    {
+        component.Tube = _container.EnsureContainer<Container>(uid, "tube");
+    }
+
+    private void OnPowerChanged(Entity<DrugInitializeMachineComponent> ent, ref PowerChangedEvent args)
+    {
+        if (!args.Powered)
+            SetAppearance(ent, DrugInitializeMachineVisualState.Idle, ent.Comp);
+    }
+
+    public void SetAppearance(EntityUid uid, DrugInitializeMachineVisualState state, DrugInitializeMachineComponent? component = null, AppearanceComponent? appearanceComponent = null)
+    {
+        if (!Resolve(uid, ref component, ref appearanceComponent, false))
+            return;
+
+        _appearance.SetData(uid, PowerDeviceVisuals.VisualState, state, appearanceComponent);
+    }
+
+    public void OnStartInitialize(EntityUid uid, DrugInitializeMachineComponent component, StartDrugInitializeEvent args)
+    {
+        if (component.IsRunning)
+            return;
+
+        if (!TryComp<DrugTestStickComponent>(args.Stick, out var drugTestStick))
+            return;
+
+        _container.Insert(args.Stick, component.Tube);
+
+        SetAppearance(uid, DrugInitializeMachineVisualState.Running, component);
+        _audio.PlayPvs(component.PrintingSound, uid);
+        component.IsRunning = true;
+        component.RunningTime = _gameTiming.CurTime + component.DurationRunning;
+    }
+
+    public void Running(EntityUid uid, DrugInitializeMachineComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        var stick = component.Tube.ContainedEntities.FirstOrDefault();
+
+        if (!TryComp<DrugTestStickComponent>(stick, out var drugTestStick))
+            return;
+
+        var dna = drugTestStick.DNA;
+        var dependencyLevel = drugTestStick.DependencyLevel;
+        var addictionLevel = (int)Math.Round(drugTestStick.AddictionLevel);
+        var tolerance = Math.Round(drugTestStick.Tolerance, 2);
+        var withdrawalLevel = (int)Math.Round(drugTestStick.WithdrawalLevel);
+        var thresholdTime = (int)Math.Round(drugTestStick.ThresholdTime);
+        thresholdTime = Math.Max(0, thresholdTime);
+
+        _container.CleanContainer(component.Tube);
+        SetAppearance(uid, DrugInitializeMachineVisualState.Idle, component);
+        var paper = Spawn(component.Paper, Transform(uid).Coordinates);
+        if (!TryComp<PaperComponent>(paper, out var paperComp))
+        {
+            QueueDel(paper);
+            return;
+        }
+
+        var content = Loc.GetString("drug-test-message-paper",
+            ("dna", dna), ("dependency", dependencyLevel), ("addiction", addictionLevel), ("tolerance", tolerance), ("withdrawal", withdrawalLevel), ("time", thresholdTime));
+
+        _paperSystem.SetContent((paper, paperComp), content);
+        component.IsRunning = false;
+    }
+}
+
+[ByRefEvent]
+public readonly record struct StartDrugInitializeEvent(EntityUid Stick);

--- a/Content.Server/DeadSpace/Drug/DrugTestStickSystem.cs
+++ b/Content.Server/DeadSpace/Drug/DrugTestStickSystem.cs
@@ -1,0 +1,61 @@
+using Content.Server.DeadSpace.Drug.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Forensics.Components;
+using Content.Shared.DeadSpace.Drug.Components;
+using Content.Shared.Popups;
+
+namespace Content.Server.DeadSpace.Drug;
+
+public sealed class DrugTestStickSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DrugTestStickComponent, AfterInteractEvent>(OnAfterInteract);
+    }
+
+    public void OnAfterInteract(EntityUid uid, DrugTestStickComponent component, AfterInteractEvent args)
+    {
+        if (!args.CanReach || args.Target == null || args.Handled)
+            return;
+
+        if (!component.IsUsed)
+        {
+            if (!HasComp<HungerComponent>(args.Target))
+                return;
+
+            if (TryComp<DnaComponent>(args.Target, out var dna))
+            {
+                component.DNA = dna.DNA;
+            }
+            else
+            {
+                component.DNA = Loc.GetString("drug-test-stick-dna");
+            }
+
+
+            if (TryComp<InstantDrugAddicationComponent>(args.Target, out var instantDrugAddication))
+            {
+                component.DependencyLevel = instantDrugAddication.DependencyLevel;
+                component.AddictionLevel = instantDrugAddication.AddictionLevel;
+                component.Tolerance = instantDrugAddication.Tolerance;
+                component.WithdrawalLevel = instantDrugAddication.WithdrawalLevel;
+                component.ThresholdTime = instantDrugAddication.SomeThresholdTime - instantDrugAddication.TimeLastAppointment;
+            }
+
+            _popup.PopupEntity(Loc.GetString("drug-test-stick-sample-taken"), args.User, args.User);
+            component.IsUsed = true;
+        }
+        else
+        {
+            if (!HasComp<DrugInitializeMachineComponent>(args.Target))
+                return;
+
+            var ev = new StartDrugInitializeEvent(uid);
+            RaiseLocalEvent(args.Target.Value, ref ev);
+        }
+    }
+}

--- a/Content.Server/DeadSpace/Drug/Effects/CureDrugIntoxication.cs
+++ b/Content.Server/DeadSpace/Drug/Effects/CureDrugIntoxication.cs
@@ -1,0 +1,30 @@
+using Content.Server.DeadSpace.Drug.Components;
+using Content.Server.DeadSpace.Drug;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeadSpace.Drug.Effects;
+
+public sealed partial class CureDrugIntoxication : EntityEffect
+{
+    [DataField]
+    public float HealStrenght = -1;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        return Loc.GetString("reagent-effect-guidebook-cure-drug-intoxication", ("chance", Probability));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var entityManager = args.EntityManager;
+
+        var instantDrugAddication = entityManager.EnsureComponent<InstantDrugAddicationComponent>(args.TargetEntity);
+
+        args.EntityManager.System<DrugAddicationSystem>().AddTimeLastAppointment(
+            args.TargetEntity,
+            HealStrenght
+            );
+    }
+}
+

--- a/Content.Server/DeadSpace/Drug/Effects/CureDrugIntoxication.cs
+++ b/Content.Server/DeadSpace/Drug/Effects/CureDrugIntoxication.cs
@@ -1,5 +1,4 @@
 using Content.Server.DeadSpace.Drug.Components;
-using Content.Server.DeadSpace.Drug;
 using Content.Shared.EntityEffects;
 using Robust.Shared.Prototypes;
 

--- a/Content.Server/DeadSpace/Drug/Effects/DrugIntoxication.cs
+++ b/Content.Server/DeadSpace/Drug/Effects/DrugIntoxication.cs
@@ -1,0 +1,55 @@
+using Content.Server.DeadSpace.Drug.Components;
+using Content.Server.DeadSpace.Drug;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server.DeadSpace.Drug.Effects;
+
+public sealed partial class DrugIntoxication : EntityEffect
+{
+    [DataField]
+    public bool Innoculate;
+
+    [DataField(required: true)]
+    public float AddictionEffect = 0;
+
+    [DataField]
+    public float ToleranceEffect = 0;
+
+    [DataField]
+    public bool ScaleByQuantity;
+
+    [DataField]
+    public int DrugStrenght = 1;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        if (Innoculate)
+            return Loc.GetString("reagent-effect-guidebook-innoculate-drug-intoxication", ("chance", Probability));
+
+        return Loc.GetString("reagent-effect-guidebook-drug-intoxication", ("chance", Probability));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var entityManager = args.EntityManager;
+
+        var instantDrugAddication = entityManager.EnsureComponent<InstantDrugAddicationComponent>(args.TargetEntity);
+
+        var scale = FixedPoint2.New(1);
+
+        if (args is EntityEffectReagentArgs reagentArgs)
+        {
+            scale = ScaleByQuantity ? reagentArgs.Quantity * reagentArgs.Scale : reagentArgs.Scale;
+        }
+
+        args.EntityManager.System<DrugAddicationSystem>().TakeDrug(
+            args.TargetEntity,
+            DrugStrenght,
+            AddictionEffect * (float)scale,
+            ToleranceEffect * (float)scale,
+            instantDrugAddication);
+    }
+}
+

--- a/Content.Server/DeadSpace/Necromorphs/InfectionDead/InitialNecroficationSystem.cs
+++ b/Content.Server/DeadSpace/Necromorphs/InfectionDead/InitialNecroficationSystem.cs
@@ -2,7 +2,6 @@
 
 using Content.Shared.DeadSpace.Necromorphs.InfectionDead.Components;
 using Content.Shared.Mobs.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeadSpace.Necromorphs.InfectionDead;
 using Content.Shared.Humanoid;
@@ -12,7 +11,6 @@ namespace Content.Server.DeadSpace.Necromorphs.InfectionDead;
 public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSystem
 {
     [Dependency] private readonly NecromorfSystem _necromorfSystem = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -20,7 +18,7 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         base.Initialize();
 
         SubscribeLocalEvent<InitialNecroficationComponent, ComponentStartup>(OnComponentStartUp);
-        SubscribeLocalEvent<InitialNecroficationComponent, StartNecroficationEvent>(StartNecrofication);
+        SubscribeLocalEvent<InitialNecroficationComponent, InitialNecroficationEvent>(StartNecrofication);
     }
 
     public override void Update(float frameTime)
@@ -31,15 +29,14 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         var necroQuery = EntityQueryEnumerator<InitialNecroficationComponent>();
         while (necroQuery.MoveNext(out var uid, out var component))
         {
-            // Process only once per second
             if (component.StartTick > curTime)
             {
                 continue;
             }
             else
             {
-                var startNecroficationEvent = new StartNecroficationEvent();
-                RaiseLocalEvent(uid, ref startNecroficationEvent);
+                var ev = new InitialNecroficationEvent();
+                RaiseLocalEvent(uid, ref ev);
                 continue;
             }
         }
@@ -53,7 +50,7 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         component.StartTick = _timing.CurTime + TimeSpan.FromSeconds(0.2);
     }
 
-    private void StartNecrofication(EntityUid uid, InitialNecroficationComponent component, StartNecroficationEvent arg)
+    private void StartNecrofication(EntityUid uid, InitialNecroficationComponent component, InitialNecroficationEvent arg)
     {
         if (HasComp<NecromorfComponent>(uid))
             return;

--- a/Content.Server/DeadSpace/Races/FelinidSystem.cs
+++ b/Content.Server/DeadSpace/Races/FelinidSystem.cs
@@ -175,7 +175,10 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.Target) || !HasComp<StatusEffectsComponent>(args.Target))
             return;
 
-        if (_robustRandom.Prob(0.2f))
+        component.VomitChance = Math.Min(1, component.VomitChance);
+        component.VomitChance = Math.Max(0, component.VomitChance);
+
+        if (_robustRandom.Prob(component.VomitChance))
             _vomitSystem.Vomit(args.Target);
     }
 
@@ -184,7 +187,10 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.User) || !HasComp<StatusEffectsComponent>(args.User))
             return;
 
-        if (_robustRandom.Prob(0.2f))
+        component.VomitChance = Math.Min(1, component.VomitChance);
+        component.VomitChance = Math.Max(0, component.VomitChance);
+
+        if (_robustRandom.Prob(component.VomitChance))
         {
             _vomitSystem.Vomit(args.User);
             args.Cancel();

--- a/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
@@ -333,14 +333,22 @@ public sealed class SpiderTerrorRuleSystem : GameRuleSystem<SpiderTerrorRuleComp
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsDeadSquadSend && component.IsStationCaptureActive(station))
         {
             component.IsDeadSquadSend = true;
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("centcomm-announcement-death-squad-team"), playSound: true, colorOverride: Color.Green);
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("spider-terror-centcomm-announcement-station-was-capture"), playSound: true, colorOverride: Color.Green);
+
+            if (TryComp<StationDataComponent>(station, out var data))
+            {
+                var msg = new GameGlobalSoundEvent(component.Sound, AudioParams.Default);
+                var stationFilter = _station.GetInStation(data);
+                stationFilter.AddPlayersByPvs(station, entityManager: EntityManager);
+                RaiseNetworkEvent(msg, stationFilter);
+            }
         }
 
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsDeadSquadArrival && component.IsStationCaptureActive(station))
         {
             component.IsDeadSquadArrival = true;
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("station-event-death-squad-team-arrival"), playSound: true, colorOverride: Color.Green);
-            GameTicker.AddGameRule("ShuttleDeathSquad");
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("station-event-response-team-arrival"), playSound: true, colorOverride: Color.Green);
+            GameTicker.AddGameRule("ShuttleCBURNSCST");
         }
 
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsCodeEpsilon && component.IsStationCaptureActive(station))
@@ -359,15 +367,6 @@ public sealed class SpiderTerrorRuleSystem : GameRuleSystem<SpiderTerrorRuleComp
         component.TimeUtilDeadSquadArrival = _timing.CurTime + component.DurationDeadSquadArrival + component.DurationDeadSquadAnnouncement;
         component.TimeUtilCodeEpsilon = _timing.CurTime + component.DurationCodeEpsilon + component.DurationDeadSquadAnnouncement + component.DurationDeadSquadArrival;
 
-        _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("spider-terror-centcomm-announcement-station-was-capture"), playSound: true, colorOverride: Color.MediumVioletRed);
-
-        if (TryComp<StationDataComponent>(station, out var data))
-        {
-            var msg = new GameGlobalSoundEvent(component.Sound, AudioParams.Default);
-            var stationFilter = _station.GetInStation(data);
-            stationFilter.AddPlayersByPvs(station, entityManager: EntityManager);
-            RaiseNetworkEvent(msg, stationFilter);
-        }
     }
 
     private (float progress, int spiderCount) GetCaptureStationProgress(EntityUid uid, EntityUid station, SpiderTerrorRuleComponent? component = null)

--- a/Content.Shared/DeadSpace/Drug/Components/DrugInitializeMachineComponent.cs
+++ b/Content.Shared/DeadSpace/Drug/Components/DrugInitializeMachineComponent.cs
@@ -1,0 +1,30 @@
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Audio;
+
+namespace Content.Shared.DeadSpace.Drug.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DrugInitializeMachineComponent : Component
+{
+    public Container Tube = default!;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public bool IsRunning = false;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan RunningTime = TimeSpan.Zero;
+
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan DurationRunning = TimeSpan.FromSeconds(5f);
+
+    [DataField("paper", required: false, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string Paper { get; set; } = "DiagnosisReportPaper";
+
+    [DataField]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public SoundSpecifier? PrintingSound = new SoundPathSpecifier("/Audio/Machines/diagnoser_printing.ogg");
+}

--- a/Content.Shared/DeadSpace/Drug/SharedDrugInitializeMachine.cs
+++ b/Content.Shared/DeadSpace/Drug/SharedDrugInitializeMachine.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.DeadSpace.Drug;
+
+[Serializable, NetSerializable]
+public enum DrugInitializeMachineVisualState
+{
+    Idle,
+    Running
+}
+
+public enum DrugInitializeMachineVisualizerLayers : byte
+{
+    Base,
+    BaseUnlit
+}
+

--- a/Content.Shared/DeadSpace/Necromorphs/InfectionDead/Components/InitialNecroficationComponent.cs
+++ b/Content.Shared/DeadSpace/Necromorphs/InfectionDead/Components/InitialNecroficationComponent.cs
@@ -17,4 +17,4 @@ public sealed partial class InitialNecroficationComponent : Component
 }
 
 [ByRefEvent]
-public readonly record struct StartNecroficationEvent();
+public readonly record struct InitialNecroficationEvent();

--- a/Resources/Locale/ru-RU/_deadspace/drug/effects.ftl
+++ b/Resources/Locale/ru-RU/_deadspace/drug/effects.ftl
@@ -1,0 +1,22 @@
+reagent-effect-guidebook-innoculate-drug-intoxication =
+    { $chance ->
+        [1] Вызывает
+       *[other] вызывают
+    } наркотическую интаксикацию и зависимость в будущем
+
+reagent-effect-guidebook-drug-intoxication =
+    { $chance ->
+        [1] Вызывает
+       *[other] вызывают
+    } наркотическую интаксикацию
+
+reagent-effect-guidebook-cure-drug-intoxication =
+    { $chance ->
+        [1] Увеличивает
+       *[other] Увеличивают
+    } время до начала наркотической ломки
+
+drug-addication-effects-medium-plus = Вас ломает, хочется принять наркотик!
+drug-addication-effects-medium = Вы чувствуете озноб и повышенное давление
+drug-addication-effects-low = Вы чувствуете слабость и навязчивое желание
+drug-addication-effects-high = Вам очень плохо, тяжело дышать, хочется принять наркотик!

--- a/Resources/Locale/ru-RU/_deadspace/drug/machine.ftl
+++ b/Resources/Locale/ru-RU/_deadspace/drug/machine.ftl
@@ -1,0 +1,12 @@
+drug-test-stick-dna = неизвестно
+drug-test-stick-sample-taken = образец взят
+
+drug-test-message-paper =
+      ДНК: {$dna}.
+      Зависимость:
+      - Тяжесть: {$dependency}.
+      - Уровень:  {$addiction}.
+      - Толерантность: {$tolerance}.
+      Ломка:
+      - Сила: {$withdrawal}.
+      - Время до/после: {$time}.

--- a/Resources/Locale/ru-RU/_deadspace/drug/narcotics.ftl
+++ b/Resources/Locale/ru-RU/_deadspace/drug/narcotics.ftl
@@ -1,0 +1,8 @@
+reagent-name-flash-dose = яркая доза
+reagent-desc-flash-dose = Запрещённое вещество, мощный наркотик с эффектом "вспышки" для быстрого привыкания.
+
+reagent-name-femaplaz = фемаплаз
+reagent-desc-femaplaz = Это лекарственный препарат, который увеличивает время до начала ломки.
+
+ent-PillFlashDose = яркая доза
+    .desc = { ent-Pill.desc }

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -19,6 +19,8 @@
   # - Virology (when it's back)
     - Botany
     - Chemicals
+  # - DeadSpace
+  - type: DrugTestStick
 
 - type: entity
   parent: BaseAmmoProvider # this is for cycling swabs out and not spawning 30 entities, trust

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -203,6 +203,11 @@
           shouldHave: false
       - !type:Drunk
         boozePower: 2
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.08
+        toleranceEffect: 0.04
+        drugStrenght: 1
 
 - type: reagent
   id: Gin

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -48,6 +48,11 @@
         key: Drowsiness
         time: 10
         type: Remove
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.4
+        toleranceEffect: 0.07
+        drugStrenght: 3
     Medicine:
       effects:
       - !type:ResetNarcolepsy
@@ -101,6 +106,11 @@
         messages: ["ephedrine-effect-tight-pain", "ephedrine-effect-heart-pounds"]
         type: Local
         probability: 0.05
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.4
+        toleranceEffect: 0.07
+        drugStrenght: 3
     Medicine:
       effects:
       - !type:ResetNarcolepsy
@@ -164,6 +174,11 @@
         key: Drowsiness
         time: 10
         type: Remove
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.1
+        toleranceEffect: 0.05
+        drugStrenght: 2
     Medicine:
       metabolismRate: 1.0
       effects:
@@ -204,6 +219,11 @@
         type: Add
         time: 16
         refresh: false
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.1
+        toleranceEffect: 0.07
+        drugStrenght: 3
 
 - type: reagent
   id: Nicotine
@@ -216,6 +236,14 @@
   plantMetabolism:
   - !type:PlantAdjustHealth
     amount: -5
+  metabolisms:
+    Narcotic:
+      effects:
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.05
+        toleranceEffect: 0.02
+        drugStrenght: 1
 
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent
@@ -250,6 +278,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 8
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.07
+        toleranceEffect: 0.02
+        drugStrenght: 3
+
 
 - type: reagent
   id: SpaceDrugs
@@ -268,6 +302,11 @@
         type: Add
         time: 5
         refresh: false
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.5
+        toleranceEffect: 0.01
+        drugStrenght: 3
 
 - type: reagent
   id: Bananadine
@@ -286,6 +325,11 @@
         type: Add
         time: 5
         refresh: false
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.2
+        toleranceEffect: 0.1
+        drugStrenght: 2
 
 # Probably replace this one with sleeping chem when putting someone in a comatose state is easier
 - type: reagent
@@ -309,6 +353,11 @@
         component: ForcedSleeping
         refresh: false
         type: Add
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.2
+        toleranceEffect: 0.01
+        drugStrenght: 1
 
 - type: reagent
   id: MuteToxin
@@ -328,6 +377,11 @@
         type: Add
         time: 10
         refresh: false
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.04
+        toleranceEffect: 0.01
+        drugStrenght: 1
 
 - type: reagent
   id: NorepinephricAcid
@@ -372,6 +426,11 @@
         conditions:
         - !type:ReagentThreshold
           min: 20
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.04
+        toleranceEffect: 0.01
+        drugStrenght: 2
 
 - type: reagent
   id: TearGas
@@ -421,6 +480,11 @@
         conditions:
         - !type:ReagentThreshold
           min: 20
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.1
+        toleranceEffect: 0.03
+        drugStrenght: 2
 
 - type: reagent
   id: Happiness
@@ -471,3 +535,8 @@
         type: Add
         time: 5
         refresh: false
+      # DeadSpace
+      - !type:DrugIntoxication
+        addictionEffect: 0.08
+        toleranceEffect: 0.03
+        drugStrenght: 2

--- a/Resources/Prototypes/_DeadSpace/Drug/entitys.yml
+++ b/Resources/Prototypes/_DeadSpace/Drug/entitys.yml
@@ -1,0 +1,78 @@
+- type: entity
+  name: flash dose
+  parent: Pill
+  id: PillFlashDose
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: FlashDose
+          Quantity: 10
+
+- type: entity
+  name: баночка для таблеток
+  parent: PillCanister
+  id: PillCanisterFlashDose
+  suffix: яркая доза 10u, 10
+  components:
+  - type: Label
+    currentLabel: FlashDose 10u
+  - type: StorageFill
+    contents:
+    - id: PillFlashDose
+      amount: 10
+
+- type: entity
+  id: DrugInitializeDiagnoserCircuitboard
+  parent: BaseMachineCircuitboard
+  name: плата машины диагностики наркотической зависимости
+  components:
+  - type: Sprite
+    state: medical
+  - type: MachineBoard
+    prototype: DrugInitializeDiagnoser
+    stackRequirements:
+      Cable: 5
+    tagRequirements:
+      GlassBeaker:
+        amount: 1
+        defaultPrototype: Beaker
+    componentRequirements:
+      BotanySwab:
+        amount: 1
+        defaultPrototype: DiseaseSwab
+
+- type: entity
+  id: DrugInitializeDiagnoser
+  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
+  name: машина диагностики наркотической зависимости
+  description: Машина, которая анализирует образцы слюны.
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: DrugInitializeMachine
+  - type: Sprite
+    sprite: Structures/Machines/diagnoser.rsi
+    layers:
+    - state: icon
+      map: ["enum.DiseaseMachineVisualLayers.IsRunning"]
+    - state: unlit
+      shader: unshaded
+      map: ["enum.DiseaseMachineVisualLayers.IsOn"]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.VisualState:
+        enum.DrugInitializeMachineVisualizerLayers.Base:
+          Idle: { state: "icon" }
+          Running: { state: "running" }
+        enum.DrugInitializeMachineVisualizerLayers.BaseUnlit:
+          Idle: { state: "unlit" }
+      enum.PowerDeviceVisuals.Powered:
+        enum.DrugInitializeMachineVisualizerLayers.BaseUnlit:
+          True: { visible: true }
+          False: { visible: false }
+  - type: Machine
+    board: DrugInitializeDiagnoserCircuitboard

--- a/Resources/Prototypes/_DeadSpace/Drug/event.yml
+++ b/Resources/Prototypes/_DeadSpace/Drug/event.yml
@@ -1,0 +1,26 @@
+- type: entity
+  name: иодид калия
+  parent: Pill
+  id: PillFlashDoseHide
+  suffix: скрытая яркая доза 10u
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: FlashDose
+          Quantity: 10
+
+- type: entity
+  name: баночка для таблеток
+  parent: PillCanister
+  id: PillCanisterFlashDoseHide
+  suffix: скрытая яркая доза 10u, 10
+  components:
+  - type: Label
+    currentLabel: PotassiumIodide 10u
+  - type: StorageFill
+    contents:
+    - id: PillFlashDoseHide
+      amount: 10

--- a/Resources/Prototypes/_DeadSpace/Drug/reagents.yml
+++ b/Resources/Prototypes/_DeadSpace/Drug/reagents.yml
@@ -1,0 +1,110 @@
+- type: reagent
+  id: FlashDose
+  name: reagent-name-flash-dose
+  group: Narcotics
+  desc: reagent-desc-flash-dose
+  physicalDesc: reagent-physical-desc-syrupy
+  flavor: bitter
+  color: "#BDB76B"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:ResetNarcolepsy
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 0.75
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 25
+        damage:
+          types:
+            Poison: 2
+            Asphyxiation: 4
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false
+      - !type:DrugIntoxication
+        addictionEffect: 1
+        toleranceEffect: 0.001
+        drugStrenght: 4
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.45
+        sprintSpeedModifier: 1.45
+      - !type:Jitter
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 5
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 5
+        type: Remove
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Haloperidol
+          max: 0.01
+        key: Drowsiness
+        time: 10
+        type: Remove
+
+- type: reagent
+  id: Femaplaz
+  name: reagent-name-femaplaz
+  group: Narcotics
+  desc: reagent-desc-femaplaz
+  physicalDesc: reagent-physical-desc-pulpy
+  flavor: flavor-base-clean
+  color: "#BC8F8F"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:CureDrugIntoxication
+        healStrenght: -10
+      - !type:GenericStatusEffect
+        key: Drunk
+        time: 8.0
+        type: Remove
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: -1
+            Asphyxiation: -1
+
+- type: reaction
+  id: Femaplaz
+  minTemp: 350
+  reactants:
+    Ethylredoxrazine:
+      amount: 1
+    Dexalin:
+      amount: 1
+  products:
+    Femaplaz: 4
+
+- type: reaction
+  id: FlashDose
+  minTemp: 400
+  reactants:
+    SpaceDrugs:
+      amount: 1
+    Dylovene:
+      amount: 1
+    Carbon:
+      amount: 1
+    Sugar:
+      amount: 1
+  products:
+    FlashDose: 4

--- a/Resources/Prototypes/_DeadSpace/Drug/reagents.yml
+++ b/Resources/Prototypes/_DeadSpace/Drug/reagents.yml
@@ -66,7 +66,7 @@
   group: Narcotics
   desc: reagent-desc-femaplaz
   physicalDesc: reagent-physical-desc-pulpy
-  flavor: flavor-base-clean
+  flavor: bitter
   color: "#BC8F8F"
   metabolisms:
     Medicine:


### PR DESCRIPTION
## Описание PR
Изменение для феленидского шара: сделал атрибут шанса на рыготу в компоненте, а не в самой системе.
Убрал эс из пауков ужаса , теперь вместо эс. прилетает доп. ОППУ.
Изменил название события инициации некрофикации.

## Почему / Зачем / Баланс
Комок шерсти: для более гибкой настройки.
Убрал эс из пауков ужаса: по просьбе из-за изменений правил вызова эскадрона смерти.
Изменил название события инициации некрофикации: чтобы название было более понятным.

## Технические детали
D:\space-station-14-fobos\Content.Server\DeadSpace\Abilities\Felinid\HairballComponent.cs
добавил ReadWrite атрибут: VomitChance 

D:\space-station-14-fobos\Content.Server\DeadSpace\Races\FelinidSystem.cs
атрибут VomitChance поместил в систему FelinidSystem.

D:\space-station-14-fobos\Content.Server\GameTicking\Rules\SpiderTerrorRuleSystem.cs
Убрал эс из пауков ужаса.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Критические изменения отсутствуют.

**Список изменений**
<!--
:cl:
- tweak: Эскадрон смерти в режиме: "Пауки ужаса" изменен на дополнительный отряд ОППУ.
-->
