### PR TITLE
Правки пауков ужаса и фелинидов

### DIFF
--- a/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
+++ b/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
@@ -4,5 +4,8 @@ namespace Content.Server.DeadSpace.Abilities.Felinid
     public sealed partial class HairballComponent : Component
     {
         public string SolutionName = "hairball";
+
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public float VomitChance = 0.2f;
     }
 }

--- a/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
+++ b/Content.Server/DeadSpace/Abilities/Felinid/HairballComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Server.DeadSpace.Abilities.Felinid
     {
         public string SolutionName = "hairball";
 
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        [DataField]
         public float VomitChance = 0.2f;
     }
 }

--- a/Content.Server/DeadSpace/Necromorphs/InfectionDead/InitialNecroficationSystem.cs
+++ b/Content.Server/DeadSpace/Necromorphs/InfectionDead/InitialNecroficationSystem.cs
@@ -2,7 +2,6 @@
 
 using Content.Shared.DeadSpace.Necromorphs.InfectionDead.Components;
 using Content.Shared.Mobs.Components;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeadSpace.Necromorphs.InfectionDead;
 using Content.Shared.Humanoid;
@@ -12,7 +11,6 @@ namespace Content.Server.DeadSpace.Necromorphs.InfectionDead;
 public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSystem
 {
     [Dependency] private readonly NecromorfSystem _necromorfSystem = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
@@ -20,7 +18,7 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         base.Initialize();
 
         SubscribeLocalEvent<InitialNecroficationComponent, ComponentStartup>(OnComponentStartUp);
-        SubscribeLocalEvent<InitialNecroficationComponent, StartNecroficationEvent>(StartNecrofication);
+        SubscribeLocalEvent<InitialNecroficationComponent, InitialNecroficationEvent>(StartNecrofication);
     }
 
     public override void Update(float frameTime)
@@ -31,15 +29,14 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         var necroQuery = EntityQueryEnumerator<InitialNecroficationComponent>();
         while (necroQuery.MoveNext(out var uid, out var component))
         {
-            // Process only once per second
             if (component.StartTick > curTime)
             {
                 continue;
             }
             else
             {
-                var startNecroficationEvent = new StartNecroficationEvent();
-                RaiseLocalEvent(uid, ref startNecroficationEvent);
+                var ev = new InitialNecroficationEvent();
+                RaiseLocalEvent(uid, ref ev);
                 continue;
             }
         }
@@ -53,7 +50,7 @@ public sealed partial class InitialNecroficationSystem : SharedInfectionDeadSyst
         component.StartTick = _timing.CurTime + TimeSpan.FromSeconds(0.2);
     }
 
-    private void StartNecrofication(EntityUid uid, InitialNecroficationComponent component, StartNecroficationEvent arg)
+    private void StartNecrofication(EntityUid uid, InitialNecroficationComponent component, InitialNecroficationEvent arg)
     {
         if (HasComp<NecromorfComponent>(uid))
             return;

--- a/Content.Server/DeadSpace/Races/FelinidSystem.cs
+++ b/Content.Server/DeadSpace/Races/FelinidSystem.cs
@@ -175,8 +175,7 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.Target) || !HasComp<StatusEffectsComponent>(args.Target))
             return;
 
-        component.VomitChance = Math.Min(1, component.VomitChance);
-        component.VomitChance = Math.Max(0, component.VomitChance);
+        component.VomitChance = Math.Clamp(component.VomitChance, 0, 1);
 
         if (_robustRandom.Prob(component.VomitChance))
             _vomitSystem.Vomit(args.Target);
@@ -187,8 +186,7 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.User) || !HasComp<StatusEffectsComponent>(args.User))
             return;
 
-        component.VomitChance = Math.Min(1, component.VomitChance);
-        component.VomitChance = Math.Max(0, component.VomitChance);
+        component.VomitChance = Math.Clamp(component.VomitChance, 0, 1);
 
         if (_robustRandom.Prob(component.VomitChance))
         {
@@ -197,4 +195,3 @@ public sealed class FelinidSystem : EntitySystem
         }
     }
 }
-

--- a/Content.Server/DeadSpace/Races/FelinidSystem.cs
+++ b/Content.Server/DeadSpace/Races/FelinidSystem.cs
@@ -175,7 +175,10 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.Target) || !HasComp<StatusEffectsComponent>(args.Target))
             return;
 
-        if (_robustRandom.Prob(0.2f))
+        component.VomitChance = Math.Min(1, component.VomitChance);
+        component.VomitChance = Math.Max(0, component.VomitChance);
+
+        if (_robustRandom.Prob(component.VomitChance))
             _vomitSystem.Vomit(args.Target);
     }
 
@@ -184,7 +187,10 @@ public sealed class FelinidSystem : EntitySystem
         if (HasComp<FelinidComponent>(args.User) || !HasComp<StatusEffectsComponent>(args.User))
             return;
 
-        if (_robustRandom.Prob(0.2f))
+        component.VomitChance = Math.Min(1, component.VomitChance);
+        component.VomitChance = Math.Max(0, component.VomitChance);
+
+        if (_robustRandom.Prob(component.VomitChance))
         {
             _vomitSystem.Vomit(args.User);
             args.Cancel();

--- a/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
@@ -333,14 +333,22 @@ public sealed class SpiderTerrorRuleSystem : GameRuleSystem<SpiderTerrorRuleComp
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsDeadSquadSend && component.IsStationCaptureActive(station))
         {
             component.IsDeadSquadSend = true;
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("centcomm-announcement-death-squad-team"), playSound: true, colorOverride: Color.Green);
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("spider-terror-centcomm-announcement-station-was-capture"), playSound: true, colorOverride: Color.Green);
+
+            if (TryComp<StationDataComponent>(station, out var data))
+            {
+                var msg = new GameGlobalSoundEvent(component.Sound, AudioParams.Default);
+                var stationFilter = _station.GetInStation(data);
+                stationFilter.AddPlayersByPvs(station, entityManager: EntityManager);
+                RaiseNetworkEvent(msg, stationFilter);
+            }
         }
 
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsDeadSquadArrival && component.IsStationCaptureActive(station))
         {
             component.IsDeadSquadArrival = true;
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("station-event-death-squad-team-arrival"), playSound: true, colorOverride: Color.Green);
-            GameTicker.AddGameRule("ShuttleDeathSquad");
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("station-event-response-team-arrival"), playSound: true, colorOverride: Color.Green);
+            GameTicker.AddGameRule("ShuttleCBURNSCST");
         }
 
         if (_timing.CurTime >= component.TimeUtilErtAnnouncement && !component.IsCodeEpsilon && component.IsStationCaptureActive(station))
@@ -359,15 +367,6 @@ public sealed class SpiderTerrorRuleSystem : GameRuleSystem<SpiderTerrorRuleComp
         component.TimeUtilDeadSquadArrival = _timing.CurTime + component.DurationDeadSquadArrival + component.DurationDeadSquadAnnouncement;
         component.TimeUtilCodeEpsilon = _timing.CurTime + component.DurationCodeEpsilon + component.DurationDeadSquadAnnouncement + component.DurationDeadSquadArrival;
 
-        _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("spider-terror-centcomm-announcement-station-was-capture"), playSound: true, colorOverride: Color.MediumVioletRed);
-
-        if (TryComp<StationDataComponent>(station, out var data))
-        {
-            var msg = new GameGlobalSoundEvent(component.Sound, AudioParams.Default);
-            var stationFilter = _station.GetInStation(data);
-            stationFilter.AddPlayersByPvs(station, entityManager: EntityManager);
-            RaiseNetworkEvent(msg, stationFilter);
-        }
     }
 
     private (float progress, int spiderCount) GetCaptureStationProgress(EntityUid uid, EntityUid station, SpiderTerrorRuleComponent? component = null)

--- a/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SpiderTerrorRuleSystem.cs
@@ -36,10 +36,10 @@ public sealed class SpiderTerrorRuleSystem : GameRuleSystem<SpiderTerrorRuleComp
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IVoteManager _voteManager = default!;
 
-    private const int SpidersBreeding = 15;
-    private const int SpidersNukeCode = 35;
-    private const float ProgressBreeding = 0.3f;
-    private const float ProgressNukeCode = 0.5f;
+    private const int SpidersBreeding = 30;
+    private const int SpidersNukeCode = 55;
+    private const float ProgressBreeding = 0.45f;
+    private const float ProgressNukeCode = 0.65f;
     private const float ProgressCaptureStation = 0.98f;
 
     private bool voteSend = false;

--- a/Content.Shared/DeadSpace/Necromorphs/InfectionDead/Components/InitialNecroficationComponent.cs
+++ b/Content.Shared/DeadSpace/Necromorphs/InfectionDead/Components/InitialNecroficationComponent.cs
@@ -17,4 +17,4 @@ public sealed partial class InitialNecroficationComponent : Component
 }
 
 [ByRefEvent]
-public readonly record struct StartNecroficationEvent();
+public readonly record struct InitialNecroficationEvent();

--- a/Resources/Prototypes/_DeadSpace/Spiders/cocoon.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/cocoon.yml
@@ -17,14 +17,14 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Damageable
     damageContainer: Biological
-  - type: Destructible
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Dead
+  - type: MobThresholds
     thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 100
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
+      0: Alive
+      100: Dead
   - type: Appearance
   - type: Evolution
     createGhostRole: true
@@ -56,14 +56,14 @@
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: Damageable
     damageContainer: Biological
-  - type: Destructible
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Dead
+  - type: MobThresholds
     thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 200
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
+      0: Alive
+      200: Dead
   - type: Appearance
   - type: Evolution
     createGhostRole: true

--- a/Resources/Prototypes/_DeadSpace/Spiders/gamerule.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/gamerule.yml
@@ -64,8 +64,8 @@
     definitions:
     - prefRoles: [ SpiderTerrorQueen ]
       fallbackRoles: [ SpiderTerrorKingBlood, SpiderTerrorKing ]
-      max: 2
-      min: 2
+      max: 3
+      min: 3
       briefing:
         text: spider-terror-quin-briefing-greeting
         color: CornflowerBlue
@@ -98,8 +98,8 @@
       - MindRoleSpiderTettorKing
     - prefRoles: [ SpiderTerrorKingBlood ]
       fallbackRoles: [ SpiderTerrorQueen, SpiderTerrorKing ]
-      max: 2
-      min: 2
+      max: 3
+      min: 3
       playerRatio: 10
       briefing:
         text: spider-terror-kingblood-briefing-greeting

--- a/Resources/Prototypes/_DeadSpace/Spiders/gamerule.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/gamerule.yml
@@ -223,9 +223,7 @@
     startAnnouncement: station-event-response-team-arrival
     startAudio:
       path: /Audio/_DeadSpace/Announcements/centcomm.ogg # DS14-Announcements
-    weight: 0
-    reoccurrenceDelay: 30
-    duration: 1
+    willNotStartRandomly: true
   - type: RuleGrids
   - type: LoadMapRule
     preloadedGrid: DeathSquadShuttle

--- a/Resources/Prototypes/_DeadSpace/Spiders/princess.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/princess.yml
@@ -49,7 +49,7 @@
     bloodMaxVolume: 250
     bloodlossThreshold: 0.4
   - type: SpawnAgainst
-    duration: 15
+    duration: 5
     spawnAgainstAction: ActionSpawnAgainst
     spawnedEntities:
       - CocoonSpider # Что спавнить

--- a/Resources/Prototypes/_DeadSpace/Spiders/queen.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/queen.yml
@@ -153,7 +153,7 @@
     thresholds:
       0: Alive
       350: Critical
-      450: Dead
+      600: Dead
   - type: Fixtures
     fixtures:
       fix1:
@@ -166,8 +166,8 @@
         layer:
         - MobLayer
   - type: MovementSpeedModifier
-    baseWalkSpeed: 3
-    baseSprintSpeed: 3
+    baseWalkSpeed: 5
+    baseSprintSpeed: 5
   - type: Bloodstream
     bloodReagent: CopperBlood
     bloodMaxVolume: 250

--- a/Resources/Prototypes/_DeadSpace/Spiders/queen.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/queen.yml
@@ -173,7 +173,7 @@
     bloodMaxVolume: 250
     bloodlossThreshold: 0.4
   - type: SpawnAgainst
-    duration: 15
+    duration: 5
     spawnAgainstAction: ActionSpawnAgainst
     spawnedEntities:
       - SpiderTomb
@@ -202,7 +202,7 @@
   - type: NeededBloodForSpawnAgainst # Пример
     defaultCost: 50 # Стандартная цена на не заданный результат
     bloodCosts: # Цены
-      SpiderTomb: 100
+      SpiderTomb: 50
       TelecomServerSpiderTerror: 200
       CocoonKingBloodSpider: 250
       CocoonSpider: 10


### PR DESCRIPTION
## Описание PR
Изменение для феленидского шара: сделал атрибут шанса на рыготу в компоненте, а не в самой системе.
Убрал эс из пауков ужаса , теперь вместо эс. прилетает доп. ОППУ.
Изменил название события инициации некрофикации.

## Почему / Зачем / Баланс
Комок шерсти: для более гибкой настройки.
Убрал эс из пауков ужаса: по просьбе из-за изменений правил вызова эскадрона смерти.
Изменил название события инициации некрофикации: чтобы название было более понятным.

## Технические детали
D:\space-station-14-fobos\Content.Server\DeadSpace\Abilities\Felinid\HairballComponent.cs
добавил ReadWrite атрибут: VomitChance 

D:\space-station-14-fobos\Content.Server\DeadSpace\Races\FelinidSystem.cs
атрибут VomitChance поместил в систему FelinidSystem.

D:\space-station-14-fobos\Content.Server\GameTicking\Rules\SpiderTerrorRuleSystem.cs
Убрал эс из пауков ужаса.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Критические изменения отсутствуют.

**Список изменений**
:cl:
- tweak: эскадрон смерти в режиме: "Пауки ужаса" изменен на дополнительный отряд ОППУ.
- tweak: количество королев и королевских пауков в начале режима увеличено до 3.
- tweak: увеличена скорость создания построек у королевы ужаса.
- tweak: снижена стоимость создания столбов.
