### PR TITLE
Исправление требований к количеству игроков у геймрулов

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -81,6 +81,7 @@
         volume: -2
     weight: 8
     duration: 35
+    minimumPlayers: 10 # DS14
   - type: AnomalySpawnRule
 
 - type: entity
@@ -422,7 +423,7 @@
     startAudio:
       path: /Audio/_DeadSpace/Announcements/lifesigns.ogg # DS14-Announcements
       params:
-        volume: -2    
+        volume: -2
     earliestStart: 20
     minimumPlayers: 15
     weight: 5

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -70,7 +70,7 @@
   components:
   - type: GameRule
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 600 # 10 min 
+    minimumTimeUntilFirstEvent: 600 # 10 min
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 930 # 17.5 min
@@ -107,7 +107,7 @@
   - type: StationEvent
     weight: 44
     earliestStart: 2
-    minimumPlayers: 0
+    minimumPlayers: 5 # DS14
   - type: MeteorSwarm
     announcement: null
     announcementSound: null
@@ -127,7 +127,7 @@
   components:
   - type: StationEvent
     weight: 22
-    minimumPlayers: 0
+    minimumPlayers: 10 # DS14
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
     announcementSound: /Audio/_DeadSpace/Announcements/attention.ogg # DS14-Announcements
@@ -159,6 +159,7 @@
   components:
   - type: StationEvent
     weight: 10
+    minimumPlayers: 20 # DS14
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
@@ -171,6 +172,7 @@
   components:
   - type: StationEvent
     weight: 5
+    minimumPlayers: 25 # DS14
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 2
@@ -183,6 +185,7 @@
   components:
   - type: StationEvent
     weight: 0.05
+    minimumPlayers: 25 # DS14
   - type: MeteorSwarm
     announcement: station-event-meteor-urist-start-announcement
     announcementSound: /Audio/_DeadSpace/Announcements/attention.ogg # DS14-Announcements

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -182,6 +182,7 @@
     startAnnouncement: null #dont nark on antags
     weight: 1 #  lower because antags.
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly (3) and because antags
+    minimumPlayers: 45 # DS14
   - type: LoadMapRule
     preloadedGrid: Instigator
 
@@ -211,6 +212,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #Leaving this one because theyre like primitives and its funnier
     weight: 1 # lower because antags
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly. (4) & antags
+    minimumPlayers: 35 # DS14
   - type: LoadMapRule
     preloadedGrid: ManOWar
 


### PR DESCRIPTION
## Описание PR
Исправлено, а местами и добавлено требование конкретного числа игроков для геймрула:
AnomalySpawn - 10, GameRuleSpaceDustMinor - 5, GameRuleSpaceDustMajor - 10, GameRuleMeteorSwarmMedium - 20, GameRuleMeteorSwarmLarge - 25, GameRuleUristSwarm (???) - 25, UnknownShuttleInstigator - 45, UnknownShuttleManOWar - 35. 

## Почему / Зачем / Баланс
Для более комфортной игры на лоупопе. Вражеские шаттлы не имели ограничений на спавн, поэтому появлялись и при 7 людях, и при 47. Для них выла выбрана золотая середина (LoneOps - 40, от него и отталкивался), чтобы это было интересно и не портило игрокам ночные смены. Это же и касается геймрулов метеоров, здесь отталкивался от GameRuleMeteorSwarm - 25, чтобы при отсутствии инженеров на ночных сменах игрокам чуть легче жилось. Ну и затронул спавн аномалии, чтобы не появлялась при менее 10 онлайна, поскольку в таком случае она скорее уничтожит станцию раньше, чем прибудут игроки, которые могут её убрать. Думаю, таким серверам как Деймос, Союз и Титан это сильно облегчит жизнь, при этом никак не повлияв на онлайн выше минимального.

## Технические детали
Были затронуты: events.yml, meteorswarm.yml, unknown_shuttles.yml, всем изменениям была добавлена приписка "# DS14".

## Медиа
Не требуется.

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- tweak: Изменены требования к онлайну у всех геймрулов метеоров (5-25), появления аномалии (10) и вражеских шаттлов (пехота 45, пираты 35) - теперь на лоупопе будет более спокойно.