### PR TITLE
Исправление требуемого онлайна карт

### DIFF
--- a/Resources/Prototypes/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Maps/Corvax/astra.yml
@@ -2,7 +2,8 @@
   id: CorvaxAstra
   mapName: 'Astra Station'
   mapPath: /Maps/corvax_astra.yml
-  minPlayers: 30
+  minPlayers: 45
+  maxPlayers: 65
   stations:
     Astra:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Maps/Corvax/avrite.yml
@@ -2,8 +2,7 @@
   id: CorvaxAvrite
   mapName: 'Avrite Station'
   mapPath: /Maps/corvax_avrit.yml
-  minPlayers: 40
-  maxPlayers: 90
+  minPlayers: 45
   stations:
     Avrit:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Maps/Corvax/delta.yml
@@ -2,7 +2,7 @@
   id: CorvaxDelta
   mapName: 'Delta Station'
   mapPath: /Maps/corvax_delta.yml
-  minPlayers: 40
+  minPlayers: 41
   stations:
     Delta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Maps/Corvax/paper.yml
@@ -2,8 +2,8 @@
   id: CorvaxPaper
   mapName: 'Paper Station'
   mapPath: /Maps/corvax_paper.yml
-  minPlayers: 14
-  maxPlayers: 65
+  minPlayers: 15
+  maxPlayers: 40
   stations:
     CorvaxPaper:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/Corvax/spectrum.yml
+++ b/Resources/Prototypes/Maps/Corvax/spectrum.yml
@@ -2,7 +2,8 @@
   id: CorvaxSpectrum
   mapName: 'Spectrum Station'
   mapPath: /Maps/corvax_spectrum.yml
-  minPlayers: 40
+  minPlayers: 50
+  maxPlayers: 75
   stations:
     Spectrum:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -2,8 +2,8 @@
   id: Amber
   mapName: 'Amber Station'
   mapPath: /Maps/amber.yml
-  minPlayers: 15
-  maxPlayers: 60
+  minPlayers: 20
+  maxPlayers: 45
   stations:
     Amber:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,8 +2,8 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 35
-  maxPlayers: 80
+  minPlayers: 30
+  maxPlayers: 75
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/barratry.yml
+++ b/Resources/Prototypes/Maps/barratry.yml
@@ -2,8 +2,8 @@
   id: Barratry
   mapName: 'Barratry Station'
   mapPath: /Maps/barratry.yml
-  minPlayers: 30
-  maxPlayers: 60
+  minPlayers: 25
+  maxPlayers: 55
   stations:
     Barratry:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,7 @@
   id: Box
   mapName: 'DS Box Station'
   mapPath: /Maps/ds_box.yml
-  minPlayers: 50
+  minPlayers: 60
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,8 +2,8 @@
   id: Cluster
   mapName: 'Cluster Station'
   mapPath: /Maps/cluster.yml
-  minPlayers: 10
-  maxPlayers: 35
+  minPlayers: 15
+  maxPlayers: 30
   stations:
     Cluster:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -2,8 +2,7 @@
   id: Cog
   mapName: 'Cog Station'
   mapPath: /Maps/cog.yml
-  minPlayers: 40
-  maxPlayers: 80 #big map
+  minPlayers: 45
   stations:
     Cog:
       stationProto: StandardNanotrasenStation
@@ -28,7 +27,7 @@
             Reporter: [ 2, 2 ]
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Zookeeper: [ 1, 1 ] 
+            Zookeeper: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -2,7 +2,7 @@
   id: Convex
   mapName: 'Convex Station'
   mapPath: /Maps/convex.yml
-  minPlayers: 75
+  minPlayers: 65
   stations:
     Convex:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,8 +2,8 @@
   id: Core
   mapName: 'Core Station'
   mapPath: /Maps/core.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 45
+  maxPlayers: 75
   stations:
     Core:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -2,8 +2,8 @@
   id: Elkridge
   mapName: 'Elkridge Depot'
   mapPath: /Maps/elkridge.yml
-  minPlayers: 15
-  maxPlayers: 45
+  minPlayers: 25
+  maxPlayers: 50
   stations:
     Elkridge:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: Fland
   mapName: 'Fland Station'
   mapPath: /Maps/fland.yml
-  minPlayers: 70
+  minPlayers: 65
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/gemini.yml
+++ b/Resources/Prototypes/Maps/gemini.yml
@@ -2,7 +2,8 @@
   id: Gemini
   mapName: 'Gemini Station'
   mapPath: /Maps/gemini.yml
-  minPlayers: 35
+  minPlayers: 30
+  maxPlayers: 50
   stations:
     Gemini:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -2,8 +2,8 @@
   id: Marathon
   mapName: 'Marathon Station'
   mapPath: /Maps/marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 30
+  maxPlayers: 65
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,8 +2,8 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
-  maxPlayers: 80
+  minPlayers: 40
+  maxPlayers: 70
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -2,7 +2,7 @@
   id: Oasis
   mapName: 'Oasis Station'
   mapPath: /Maps/oasis.yml
-  minPlayers: 70
+  minPlayers: 60
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,8 +2,8 @@
   id: Omega
   mapName: 'Omega Station'
   mapPath: /Maps/omega.yml
-  minPlayers: 10
-  maxPlayers: 35
+  minPlayers: 15
+  maxPlayers: 40
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -2,7 +2,8 @@
   id: Origin
   mapName: 'Origin Station'
   mapPath: /Maps/origin.yml
-  minPlayers: 60
+  minPlayers: 50
+  maxPlayers: 70
   stations:
     Origin:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -3,7 +3,7 @@
   mapName: 'Packed Station'
   mapPath: /Maps/packed.yml
   minPlayers: 7
-  maxPlayers: 35
+  maxPlayers: 37
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -2,8 +2,8 @@
   id: Plasma
   mapName: 'Plasma Station'
   mapPath: /Maps/plasma.yml
-  minPlayers: 30
-  maxPlayers: 80
+  minPlayers: 25
+  maxPlayers: 65
   stations:
     Plasma:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -2,7 +2,7 @@
   id: Saltern
   mapName: 'Saltern Station'
   mapPath: /Maps/saltern.yml
-  minPlayers: 0
+  minPlayers: 7
   maxPlayers: 35
   fallback: true
   stations:

--- a/Resources/Prototypes/Maps/silly.yml
+++ b/Resources/Prototypes/Maps/silly.yml
@@ -5,7 +5,7 @@
   maxRandomOffset: 0
   randomRotation: false
   minPlayers: 0
-  maxPlayers: 30
+  maxPlayers: 35
   stations:
     Silly:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
## Описание PR
Были изменены требования минимального/максимального онлайна у большинства карт.

## Почему / Зачем / Баланс
Требуемые значения были обговорены со старшим маппером. Сделано для улучшения подбора карт и большей вариативности этих самых карт. Аврит имел ограничение на онлайн, так что на хайпопе не мог выпасть, как пример.

## Технические детали
Были изменены значения онлайна в оригинальных прототипах карт, местами удалены/добавлен maxPlayers.

## Медиа
Не требуется.

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- tweak: Изменены требования онлайна для подбора большинства карт. Теперь вариативность их выпадения должна быть выше при любом онлайне.
