### PR TITLE
Изменение РСУ СИ

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Tools/tools.yml
@@ -8,5 +8,24 @@
     sprite: _DeadSpace/Objects/Tools/cercd.rsi
     layers:
     - state: icon
-  - type: AutoRecharge
-    rechargeDuration: 120
+  - type: RCD
+    availablePrototypes:
+    - WallSolidCE
+    - FloorSteel
+    - Plating
+    - Catwalk
+    - GrilleCE
+    - WindowCE
+    - WindowDirectionalCE
+    - WindowReinforcedDirectionalCE
+    - ReinforcedWindowCE
+    - AirlockCE
+    - AirlockGlassCE
+    - FirelockCE
+    - TubeLightCE
+    - BulbLightCE
+    - LVCable
+    - MVCable
+    - HVCable
+    - CableTerminal
+    - Deconstruct

--- a/Resources/Prototypes/_DeadSpace/RCD/rcd.yml
+++ b/Resources/Prototypes/_DeadSpace/RCD/rcd.yml
@@ -1,0 +1,147 @@
+# Walls
+- type: rcd
+  id: WallSolidCE
+  category: WallsAndFlooring
+  sprite: /Textures/Interface/Radial/RCD/solid_wall.png
+  mode: ConstructObject
+  prototype: WallSolid 
+  cost: 2
+  delay: 2
+  collisionMask: FullTileMask
+  rotation: Fixed
+  fx: EffectRCDConstruct2
+
+- type: rcd
+  id: GrilleCE
+  category: WindowsAndGrilles
+  sprite: /Textures/Interface/Radial/RCD/grille.png
+  mode: ConstructObject
+  prototype: Grille
+  cost: 2
+  delay: 2
+  collisionMask: Impassable
+  rotation: Fixed
+  fx: EffectRCDConstruct2
+
+# Windows
+- type: rcd
+  id: WindowCE
+  category: WindowsAndGrillesCE
+  sprite: /Textures/Interface/Radial/RCD/window.png
+  mode: ConstructObject
+  prototype: Window
+  cost: 2
+  delay: 2
+  collisionMask: Impassable
+  rules:
+    - IsWindow
+  rotation: Fixed
+  fx: EffectRCDConstruct2
+  
+- type: rcd
+  id: WindowDirectionalCE
+  category: WindowsAndGrilles
+  sprite: /Textures/Interface/Radial/RCD/directional.png
+  mode: ConstructObject
+  prototype: WindowDirectional
+  cost: 1
+  delay: 1
+  collisionMask: Impassable
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rules:
+    - IsWindow
+  rotation: User
+  fx: EffectRCDConstruct1
+  
+- type: rcd
+  id: ReinforcedWindowCE
+  category: WindowsAndGrilles
+  sprite: /Textures/Interface/Radial/RCD/window_reinforced.png
+  mode: ConstructObject
+  prototype: ReinforcedWindow
+  cost: 2
+  delay: 3
+  collisionMask: Impassable
+  rules:
+    - IsWindow
+  rotation: User
+  fx: EffectRCDConstruct3
+    
+- type: rcd
+  id: WindowReinforcedDirectionalCE
+  category: WindowsAndGrilles
+  sprite: /Textures/Interface/Radial/RCD/directional_reinforced.png
+  mode: ConstructObject
+  prototype: WindowReinforcedDirectional
+  cost: 1
+  delay: 2
+  collisionMask: Impassable
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rules:
+    - IsWindow
+  rotation: User
+  fx: EffectRCDConstruct2
+
+# Airlocks
+- type: rcd
+  id: AirlockCE
+  category: Airlocks
+  sprite: /Textures/Interface/Radial/RCD/airlock.png
+  mode: ConstructObject
+  prototype: Airlock
+  cost: 2
+  delay: 4
+  collisionMask: FullTileMask
+  rotation: Camera
+  fx: EffectRCDConstruct4
+  
+- type: rcd
+  id: AirlockGlassCE
+  category: Airlocks
+  sprite: /Textures/Interface/Radial/RCD/glass_airlock.png
+  mode: ConstructObject
+  prototype: AirlockGlass
+  cost: 2
+  delay: 4
+  collisionMask: FullTileMask
+  rotation: Camera
+  fx: EffectRCDConstruct4
+  
+- type: rcd
+  id: FirelockCE
+  category: Airlocks
+  sprite: /Textures/Interface/Radial/RCD/firelock.png
+  mode: ConstructObject
+  prototype: Firelock
+  cost: 2
+  delay: 3
+  collisionMask: FullTileMask
+  rotation: Camera
+  fx: EffectRCDConstruct3
+
+# Lighting
+- type: rcd
+  id: TubeLightCE
+  category: Lighting
+  sprite: /Textures/Interface/Radial/RCD/tube_light.png
+  mode: ConstructObject
+  prototype: Poweredlight
+  cost: 1
+  delay: 1
+  collisionMask: TabletopMachineMask
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rotation: User
+  fx: EffectRCDConstruct1
+  
+- type: rcd
+  id: BulbLightCE
+  category: Lighting
+  sprite: /Textures/Interface/Radial/RCD/bulb_light.png
+  mode: ConstructObject
+  prototype: PoweredSmallLight
+  cost: 1
+  delay: 1
+  collisionMask: TabletopMachineMask
+  collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rotation: User
+  fx: EffectRCDConstruct1


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
<!-- Что вы изменили? -->
Изменение цен РСУ СИ
## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. --> Хахич попросил

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Создана папка прототипа RCD
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
Не требуется
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Нет
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Убрано автовосстановление зарядов у РСУ СИ, теперь вместо этого он использует их меньше для постройки.
