### PR TITLE
Фикс слоя наложения одеялок

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -10,7 +10,7 @@
     - Bed
   components:
   - type: Sprite
-    drawdepth: Overdoors # DS14
+    drawdepth: OverMobs # DS14
     sprite: Objects/Misc/bedsheets.rsi
     noRot: true
   - type: Item

--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Misc/bedsheets.yml
@@ -8,7 +8,7 @@
     - Bed
   components:
   - type: Sprite
-    drawdepth: Overdoors
+    drawdepth: OverMobs
     sprite: _DeadSpace/Objects/Misc/bedsheets.rsi
     noRot: true
   - type: Item


### PR DESCRIPTION
## Описание PR
Изменил слой наложения одеялок в OverDoors на OverMobs. Выполняет ту же задачу, но не закрывает твёрдые объекты.

## Почему / Зачем / Баланс
Надо чинить.

## Технические детали
Изменил по одному значению в прототипах односпальных и двухспальных одеялок

## Медиа
Нет

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- fix: Одеяльца теперь не перекрывают твёрдые структуры.