### PR TITLE
Исправление локализации меню миди-инструментов

### DIFF
--- a/Resources/Locale/ru-RU/instruments/instruments-component.ftl
+++ b/Resources/Locale/ru-RU/instruments/instruments-component.ftl
@@ -9,8 +9,8 @@ instruments-component-menu-no-midi-support =
     FluidSynth или пакет разработки
     для FluidSynth.
 instruments-component-menu-input-button = MIDI-ввод
-instruments-component-menu-band-button = Присоединиться к группе
-instruments-component-menu-play-button = Воспроизвести MIDI-файл
+instruments-component-menu-band-button = Присоединиться
+instruments-component-menu-play-button = MIDI-файл
 instruments-component-menu-loop-button = Повтор
 instruments-component-menu-channels-button = Каналы
 instruments-component-menu-stop-button = Стоп


### PR DESCRIPTION
## Описание PR
Убрано по слову в локализации, дабы меню не выглядело паршивенько. Лучший вариант, чтобы не растягивать UI менюшки

## Почему / Зачем / Баланс
По баг-репорту https://discordapp.com/channels/1030160796401016883/1361271027010895903
На баланс не влияет, но внутренний перфекционист счастлив 

## Технические детали
Удалены два слова в файле локализации MIDI-инструментов

## Медиа
Было:
![image](https://github.com/user-attachments/assets/55a875a0-4016-4dd4-86db-04fbf5c038ee)
Стало:
![image](https://github.com/user-attachments/assets/07b43cea-991c-474f-9007-a21bd4cab35b)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Исправлено меню MIDI-инструментов. 
