### PR TITLE
Рефлект лазерному автомату и доминатору

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Weapons/Guns/Battery/dominator.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Weapons/Guns/Battery/dominator.yml
@@ -72,3 +72,6 @@
     damage:
       types:
         Heat: 16
+  - type: Reflective
+    reflective:
+    - Energy


### PR DESCRIPTION
## Описание PR
Добавлен рефлект проджектайлу доминатора, от него наследуется и снаряду лазерного автомата.

## Почему / Зачем / Баланс
По неизвестной причине эти снаряды не отражались лазерным мечом, щитом и прочим. В угоду логике и баланса было исправлено, наравне с любыми другими энерго-снарядами отражаются.

## Технические детали
Изменён прототип летальных снарядов доминатора - Resources/Prototypes/_DeadSpace/Entities/Objects/Weapons/Guns/Battery/dominator.yml

## Медиа
![jDVT6vJHYm](https://github.com/user-attachments/assets/af631e27-fd25-43a3-a278-2d887a947ab8)
![Content Client_J7UoWSk47L](https://github.com/user-attachments/assets/2824dae1-08d0-4127-bf30-047c2a445a0a)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Заряды доминатора и лазерного автомата теперь исправно отражаются лазерным мечом / щитом.