### PR TITLE
Исправление и дополнение лоадаутов

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -42,6 +42,14 @@
     neck: ClothingNeckCloakHop
 
 - type: loadout
+  id: HoPAltCloak
+  equipment:
+    neck: ADTClothingNeckHoPAltCloak
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ProfessionalHoP
+
+- type: loadout
   id: HoPMantle
   equipment:
     neck: ClothingNeckMantleHOP

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -8,6 +8,16 @@
       role: JobChiefMedicalOfficer
       time: 72000 #20 hrs
 
+# Professional CMO Time
+- type: loadoutEffectGroup
+  id: ProfessionalCMO
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChiefMedicalOfficer
+      time: 54000 #15 hrs
+
 # Jumpsuit
 - type: loadout
   id: ChiefMedicalOfficerJumpsuit
@@ -58,6 +68,15 @@
   id: ChiefMedicalOfficerMantle
   equipment:
     neck: ClothingNeckMantleCMO
+
+# Back
+- type: loadout
+  id: ChiefMedicalOfficerSatchelBlueCat
+  equipment:
+    back: ClothingSatchelBlueCat
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: ProfessionalCMO
 
 # Outer clothing
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -130,11 +130,6 @@
   equipment:
     back: ClothingBackpackDuffelMedical
 
-- type: loadout
-  id: MedicalDoctorSatchelBlueCat
-  equipment:
-    back: ClothingSatchelBlueCat
-
 # OuterClothing
 - type: loadout
   id: MedicalDoctorWintercoat

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -65,6 +65,15 @@
     - Lighter
 
 - type: loadout
+  id: FlippoLighter
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: Command
+  storage:
+    back:
+    - FlippoLighter
+
+- type: loadout
   id: CigPackGreen
   storage:
     back:
@@ -106,102 +115,60 @@
     back:
     - CigarGold
 
-# Pins
+# Pins (without LGBTQ+ pins)
 - type: loadout
-  id: ClothingNeckLGBTPin
+  id: ClothingNeckUSSPPin
   storage:
     back:
-    - ClothingNeckLGBTPin
+    - ClothingNeckUSSPPin
 
 - type: loadout
-  id: ClothingNeckAllyPin
+  id: ClothingNeckDonkPin
   storage:
     back:
-    - ClothingNeckAllyPin
+    - ClothingNeckDonkPin
 
 - type: loadout
-  id: ClothingNeckAromanticPin
+  id: ClothingNeckEarthPin
   storage:
     back:
-    - ClothingNeckAromanticPin
+    - ClothingNeckEarthPin
 
 - type: loadout
-  id: ClothingNeckAsexualPin
+  id: ClothingNeckLogistikaPin
   storage:
     back:
-    - ClothingNeckAsexualPin
+    - ClothingNeckLogistikaPin
 
 - type: loadout
-  id: ClothingNeckAroacePin
+  id: ClothingNeckDeForestPin
   storage:
     back:
-    - ClothingNeckAroacePin
+    - ClothingNeckDeForestPin
 
 - type: loadout
-  id: ClothingNeckBisexualPin
+  id: ClothingNeckNakamuraPin
   storage:
     back:
-    - ClothingNeckBisexualPin
+    - ClothingNeckNakamuraPin
 
 - type: loadout
-  id: ClothingNeckGayPin
+  id: ClothingNeckNanoTrasenPin
   storage:
     back:
-    - ClothingNeckGayPin
+    - ClothingNeckNanoTrasenPin
 
 - type: loadout
-  id: ClothingNeckIntersexPin
+  id: ClothingNeckSyndicakePin
   storage:
     back:
-    - ClothingNeckIntersexPin
+    - ClothingNeckSyndicakePin
 
 - type: loadout
-  id: ClothingNeckLesbianPin
+  id: ClothingNeckVitezstviPin
   storage:
     back:
-    - ClothingNeckLesbianPin
-
-- type: loadout
-  id: ClothingNeckNonBinaryPin
-  storage:
-    back:
-    - ClothingNeckNonBinaryPin
-
-- type: loadout
-  id: ClothingNeckPansexualPin
-  storage:
-    back:
-    - ClothingNeckPansexualPin
-
-- type: loadout
-  id: ClothingNeckOmnisexualPin
-  storage:
-    back:
-    - ClothingNeckOmnisexualPin
-
-- type: loadout
-  id: ClothingNeckGenderqueerPin
-  storage:
-    back:
-    - ClothingNeckGenderqueerPin
-
-- type: loadout
-  id: ClothingNeckTransPin
-  storage:
-    back:
-    - ClothingNeckTransPin
-
-- type: loadout
-  id: ClothingNeckAutismPin
-  storage:
-    back:
-    - ClothingNeckAutismPin
-
-- type: loadout
-  id: ClothingNeckGoldAutismPin
-  storage:
-    back:
-    - ClothingNeckGoldAutismPin
+    - ClothingNeckVitezstviPin
 
 # Towels
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -13,28 +13,22 @@
   - PlushieSpaceLizard
   - ThreeCandles
   - Lighter
+  - FlippoLighter
   - CigPackGreen
   - CigPackRed
   - CigPackBlue
   - CigPackBlack
   - CigarCase
   - CigarGold
-  - ClothingNeckLGBTPin
-  - ClothingNeckAllyPin
-  - ClothingNeckAromanticPin
-  - ClothingNeckAsexualPin
-  - ClothingNeckAroacePin
-  - ClothingNeckBisexualPin
-  - ClothingNeckGayPin
-  - ClothingNeckIntersexPin
-  - ClothingNeckLesbianPin
-  - ClothingNeckNonBinaryPin
-  - ClothingNeckPansexualPin
-  - ClothingNeckOmnisexualPin
-  - ClothingNeckGenderqueerPin
-  - ClothingNeckTransPin
-  - ClothingNeckAutismPin
-  - ClothingNeckGoldAutismPin
+  - ClothingNeckUSSPPin
+  - ClothingNeckDonkPin
+  - ClothingNeckEarthPin
+  - ClothingNeckLogistikaPin
+  - ClothingNeckDeForestPin
+  - ClothingNeckNakamuraPin
+  - ClothingNeckNanoTrasenPin
+  - ClothingNeckSyndicakePin
+  - ClothingNeckVitezstviPin
   - CorporateLaw # Corvax-HyperLink
   - TowelColorBlack
   - TowelColorDarkBlue
@@ -182,6 +176,7 @@
   minLimit: 0
   loadouts:
   - HoPCloak
+  - HoPAltCloak
   - HoPMantle
 
 - type: loadoutGroup
@@ -206,7 +201,7 @@
   loadouts:
   - ShoesBootsLaceup
   - BrownShoes
-  
+
 - type: loadoutGroup
   id: HoPUnderwear
   name: loadout-group-hop-underwear
@@ -354,7 +349,7 @@
   name: loadout-group-chef-hand
   minLimit: 0
   loadouts:
-  - ChefGoldenKnife  
+  - ChefGoldenKnife
 
 - type: loadoutGroup
   id: ChefGloves
@@ -618,7 +613,7 @@
   - EmergencyOxygenClown
   # DS14-species-emergency-start
   - EmergencyNonBreather
-  - EmergencyRobotNonBreather  
+  - EmergencyRobotNonBreather
   # DS14-species-emergency-end
   - LoadoutSpeciesVoxNitrogen
   - EmergencyBeerClown
@@ -687,7 +682,7 @@
   - EmergencyOxygenMime
   # DS14-species-emergency-start
   - EmergencyNonBreather
-  - EmergencyRobotNonBreather  
+  - EmergencyRobotNonBreather
   # DS14-species-emergency-end
   - LoadoutSpeciesVoxNitrogen
   - EmergencyBeerMime
@@ -888,7 +883,7 @@
   - SalvageSpecialistJumpsuitFormal
   - SalvageSpecialistJumpskirt
   - SalvageSpecialistJumpskirtFormal
-  
+
 - type: loadoutGroup
   id: SalvageSpecialistOuterClothing
   name: loadout-group-salvage-specialist-outerclothing
@@ -1584,7 +1579,7 @@
   - MedicalDoctorBackpack
   - MedicalDoctorSatchel
   - MedicalDoctorDuffel
-  - MedicalDoctorSatchelBlueCat
+  - ChiefMedicalOfficerSatchelBlueCat
 
 - type: loadoutGroup
   id: ChiefMedicalOfficerNeck


### PR DESCRIPTION
## Описание PR
Изменения в лоадаутах - разноцветные значки были заменены на значки корпораций, добавлена зажигалка флиппо с требованием 1 час командования (аналогично сигарам), моя кошачья сумка гв была перенесена в его лоадаут, к ней добавлены изначально задуманные требования - 15 часов (по аналогии с рюкзаком гп), гп был добавлен торжественный плащ с требованием наиграть 15 часов.

## Почему / Зачем / Баланс
По просьбам игроков, во благо логики и удобства. На баланс никак не влияет

## Технические детали
Были изменены лоадауты ГП, ГВ, общие "безделушки", из медицинского удалена сумка гв

## Медиа
![Content Client_ylEK8jQWAP](https://github.com/user-attachments/assets/ee8dfa7a-14e8-4f05-b0c2-19ae40466a7e)
![Content Client_uI8N9xj3yg](https://github.com/user-attachments/assets/58f3688a-a81f-4f41-9f87-bfc893232424)
![Content Client_KbafePyuwf](https://github.com/user-attachments/assets/64544381-1a1a-4336-904c-596f51c26434)
![Content Client_CalXd8OSmL](https://github.com/user-attachments/assets/f43fbc29-a775-49af-bdb1-acbf97ebcacc)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- add: В лоадаут добавлена зажигалка флиппо (1 час командования), ГП добавлен торжественный плащ (15 часов на ГП).
- tweak: Радужные значки заменены на значки корпораций. Кошачья сумка ГВ теперь требует 15 часов на должности для открытия.
