### PR TITLE
Лисий хвостик метеора доступен слаймолюдам

### DIFF
--- a/Resources/Prototypes/_ADT/Customization/Markings/foxtails.yml
+++ b/Resources/Prototypes/_ADT/Customization/Markings/foxtails.yml
@@ -2,7 +2,7 @@
   id: ADTFoxTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin]
+  speciesRestriction: [Human, Dwarf, Felinid, Vulpkanin, SlimePerson]
   sponsorOnly: True
   coloring:
     default:


### PR DESCRIPTION
## Описание PR
Слаймолюды добавлены в вайтлист рас, которые могут использовать лисий хвостик

## Почему / Зачем / Баланс
По предложению https://discord.com/channels/1030160796401016883/1367482145018351626
На баланс не влияет, выглядит хорошо, имеет прозрачность и оттенок тела слаймолюда. Метеоры будут счастливы.

## Технические детали
Изменён Resources/Prototypes/_ADT/Customization/Markings/foxtails.yml , добавлен SlimePerson в список допустимых рас.

## Медиа
![image](https://github.com/user-attachments/assets/80f2f0ed-4cda-4a8e-9e35-9a6f22aadabb)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Теперь слаймолюды могут иметь лисий хвостик (Метеор).