### PR TITLE
Доступы к консолям заказа у глав

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1015,7 +1015,7 @@
   - type: PointLight
     color: "#c9c042"
   - type: AccessReader
-    access: [["Engineering"]]
+    access: [["ChiefEngineer"]]
 
 - type: entity
   id: ComputerCargoOrdersMedical
@@ -1047,7 +1047,7 @@
   - type: PointLight
     color: "#41e0fc"
   - type: AccessReader
-    access: [["Medical"]]
+    access: [["ChiefMedicalOfficer"]]
 
 - type: entity
   id: ComputerCargoOrdersScience
@@ -1079,7 +1079,7 @@
   - type: PointLight
     color: "#b53ca1"
   - type: AccessReader
-    access: [["Research"]]
+    access: [["ResearchDirector"]]
 
 - type: entity
   id: ComputerCargoOrdersSecurity
@@ -1111,7 +1111,7 @@
   - type: PointLight
     color: "#d11d00"
   - type: AccessReader
-    access: [["Security"]]
+    access: [["Armory"]]
 
 - type: entity
   id: ComputerCargoOrdersService
@@ -1143,7 +1143,7 @@
   - type: PointLight
     color: "#afe837"
   - type: AccessReader
-    access: [["Service"]]
+    access: [["HeadOfPersonnel"]]
 
 - type: entity
   id: ComputerCargoBounty


### PR DESCRIPTION
## Описание PR
Доступ к одобрению заказов есть только у глав (и смотрителя). 

## Почему / Зачем / Баланс
Обычные сотрудники станции заказывают всё подряд, что негативно сказывается на работе карго. По аналогии с обычной консолью заказов карго (снабжение -> квартирмейстер) доступы были заменены для более ответственного подхода. Консоли заказа СБ сделаны доступы оружейной, чтобы смотритель мог сам заказать необходимое для работы брига. На баланс не влияет.

## Технические детали
Изменены доступы в Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Теперь консоли заказов отделов требуют доступ главы. В СБ требуется доступ оружейной.