### PR TITLE
Фикс работы перчаток "Аркалис" в некорректных слотах

### DIFF
--- a/Content.Server/DeadSpace/Arkalyse/ArkalyseGlovesSystem.cs
+++ b/Content.Server/DeadSpace/Arkalyse/ArkalyseGlovesSystem.cs
@@ -17,6 +17,11 @@ public sealed partial class ArkalyseGlovesSystem : EntitySystem
     }
     private void OnEquipped(EntityUid uid, ArkalyseGlovesComponent component, GotEquippedEvent args)
     {
+        if (args.SlotFlags != Shared.Inventory.SlotFlags.GLOVES)
+        {
+            return;
+        }
+
         if (!HasComp<ArkalyseStunComponent>(args.Equipee) || !HasComp<ArkalyseDamageComponent>(args.Equipee) || !HasComp<ArkalyseMutedComponent>(args.Equipee))
         {
             var stunComponent = EnsureComp<ArkalyseStunComponent>(args.Equipee);


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
Исправляет работу перчаток "Аркалис" в любых слотах экипировки - т.е в карманах или просто в руках.

## Почему / Зачем / Баланс
Баг.

## Технические детали
PR добавляет проверку слота, в который были "экипированы" перчатки, в систему Аркалиса. Если слот не перчаточный, делается return.

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- fix: Исправлена работа перчаток "Аркалис" в некорректных слотах