### PR TITLE
Исправление геймрулов пиратов и волшебника

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -337,7 +337,7 @@
     duration: 1
     earliestStart: 30
     reoccurrenceDelay: 60
-    minimumPlayers: 10
+    minimumPlayers: 30 # DS14
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -335,7 +335,7 @@
   - type: StationEvent
     weight: 1 # rare
     duration: 1
-    earliestStart: 30
+    earliestStart: 50 # DS14
     reoccurrenceDelay: 60
     minimumPlayers: 30 # DS14
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -288,7 +288,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 30
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -288,7 +288,7 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 30
+    minPlayers: 30 # DS14
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -20,7 +20,6 @@
     - id: UnknownShuttleMeatZone
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
-    - id: UnknownShuttlePirate # DS14
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -35,6 +34,7 @@
     - id: LoneOpsSpawn
     - id: UnknownShuttleManOWar
     - id: UnknownShuttleInstigator
+    - id: UnknownShuttlePirate # DS14
 
 # Shuttle Game Rules
 
@@ -212,8 +212,8 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #Leaving this one because theyre like primitives and its funnier
     weight: 1 # lower because antags
-    earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly. (4) & antags
-    minimumPlayers: 35 # DS14
+    earliestStart: 30 # late to hopefully have enough ghosts to fill all roles quickly. (4) & antags
+    minimumPlayers: 25 # DS14
   - type: LoadMapRule
     preloadedGrid: ManOWar
 
@@ -254,5 +254,8 @@
   components:
   - type: StationEvent
     startAnnouncement: null
+    weight: 1 # lower because antags
+    earliestStart: 40 # late to hopefully have enough ghosts to fill all roles quickly
+    minimumPlayers: 35 # DS14
   - type: LoadMapRule
     preloadedGrid: Pirate


### PR DESCRIPTION
## Описание PR
Исправил пиратов - теперь они в пуле вражеских шаттлов и не будут появляться во время гриншифта, Добавил им требование - от 40 минут и от 35 игроков. Взамен сделал спавн мужиков с копьями более частым - от 30 минуты и от 25 игроков. Так же изменил спавн волшебника - от 50 минут и от 30 игроков самостоятельно, раундстартом от 30 игроков - во избежание спавна волшебника на ночной онлайн в 5 человек.

## Почему / Зачем / Баланс
Исправление косяков автора пиратов - теперь они не будут появляться очень рано, на лоупопе и гриншифте. Волшебник же один из сильнейших антагонистов, а требовал всего 10 онлайна и появлялся на 30 минуте регулярно. На баланс не повлияет.

## Технические детали
Код изменён не был, изменены значения в оригинальных прототипах официальных разработчиков.

## Медиа
Не требуется.

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- fix: Исправлены геймрулы пиратов и волшебника - больше они не будут тревожить гриншифт и лоупоп.
