### PR TITLE
Добавление туфель в стартовый лоадаут АВД

### DIFF
--- a/Resources/Prototypes/_Corvax/Roles/Jobs/Command/iaa.yml
+++ b/Resources/Prototypes/_Corvax/Roles/Jobs/Command/iaa.yml
@@ -41,7 +41,7 @@
 - type: startingGear
   id: IAAGear
   equipment:
-    shoes: ClothingShoesColorBlack
+    shoes: ClothingShoesBootsLaceup
     id: IAAPDA
     eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetIAA


### PR DESCRIPTION
## Описание PR
Добавил шнурованные туфли в лоадаут АВД. Изначально думал сделать выбор, но будто бы оставлять кроссовки ему - не очень вариант.

## Почему / Зачем / Баланс
По предложению https://discord.com/channels/1030160796401016883/1362188989926346822
На баланс не влияет, игроки на АВД будут счастливы

## Технические детали
Затронут прототип роли АВД - Resources/Prototypes/_Corvax/Roles/Jobs/Command/iaa.yml

## Медиа
![image](https://github.com/user-attachments/assets/c15cd743-3fc8-434f-89f9-8d2225ab5e8e)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- tweak: NT повысили финансирование АВД и заменили ему обувь на шнурованные туфли.
