### PR TITLE
Фиолетовые туфли и светоотражающий жилет уборщику в лоадаут и торгомат

### DIFF
--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -64,6 +64,7 @@ loadout-group-janitor-head = Janitor head
 loadout-group-janitor-jumpsuit = Janitor jumpsuit
 loadout-group-janitor-gloves = Janitor gloves
 loadout-group-janitor-outerclothing = Janitor outer clothing
+loadout-group-janitor-shoes = Janitor shoes
 loadout-group-janitor-plunger = Janitor plunger
 
 loadout-group-botanist-head = Botanist head

--- a/Resources/Locale/ru-RU/preferences/loadout-groups.ftl
+++ b/Resources/Locale/ru-RU/preferences/loadout-groups.ftl
@@ -68,6 +68,7 @@ loadout-group-janitor-head = Уборщик, голова
 loadout-group-janitor-jumpsuit = Уборщик, комбинезон
 loadout-group-janitor-gloves = Уборщик, перчатки
 loadout-group-janitor-outerclothing = Уборщик, верхняя одежда
+loadout-group-janitor-shoes = Уборщик, обувь
 loadout-group-janitor-plunger = Уборщик, вантуз
 loadout-group-janitor-underwear = Уборщик, нижнее бельё
 loadout-group-botanist-head = Ботаник, голова

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -4,12 +4,13 @@
     ClothingUniformJumpsuitJanitor: 2
     ClothingUniformJumpskirtJanitor: 2
     ClothingHandsGlovesJanitor: 2
-    ClothingShoesColorBlack: 2
+    ClothingShoesColorPurple: 2
     ClothingShoesGaloshes: 1
     ClothingHeadHatPurplesoft: 2
     ClothingBeltJanitor: 2
     ClothingHeadsetService: 2
     ClothingOuterWinterJani: 2
+    ClothingOuterVestHazard: 2
     ClothingNeckScarfStripedPurple: 3
   contrabandInventory:
     ToyFigurineJanitor: 1

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -46,6 +46,22 @@
   equipment:
     outerClothing: ClothingOuterWinterJani
 
+- type: loadout
+  id: JanitorHazardVest
+  equipment:
+    outerClothing: ClothingOuterVestHazard
+
+# Shoes
+- type: loadout
+  id: PurpleShoes
+  equipment:
+    shoes: ClothingShoesColorPurple
+
+- type: loadout
+  id: GaloshesShoes
+  equipment:
+    shoes: ClothingShoesGaloshes
+
 # Misc
 - type: loadout
   id: JanitorGoldenPlunger

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -206,7 +206,7 @@
   loadouts:
   - ShoesBootsLaceup
   - BrownShoes
-  
+
 - type: loadoutGroup
   id: HoPUnderwear
   name: loadout-group-hop-underwear
@@ -354,7 +354,7 @@
   name: loadout-group-chef-hand
   minLimit: 0
   loadouts:
-  - ChefGoldenKnife  
+  - ChefGoldenKnife
 
 - type: loadoutGroup
   id: ChefGloves
@@ -497,6 +497,14 @@
   minLimit: 0
   loadouts:
   - JanitorWintercoat
+  - JanitorHazardVest
+
+- type: loadoutGroup
+  id: JanitorShoes
+  name: loadout-group-janitor-shoes
+  loadouts:
+  - PurpleShoes
+  - GaloshesShoes
 
 - type: loadoutGroup
   id: JanitorPlunger
@@ -618,7 +626,7 @@
   - EmergencyOxygenClown
   # DS14-species-emergency-start
   - EmergencyNonBreather
-  - EmergencyRobotNonBreather  
+  - EmergencyRobotNonBreather
   # DS14-species-emergency-end
   - LoadoutSpeciesVoxNitrogen
   - EmergencyBeerClown
@@ -687,7 +695,7 @@
   - EmergencyOxygenMime
   # DS14-species-emergency-start
   - EmergencyNonBreather
-  - EmergencyRobotNonBreather  
+  - EmergencyRobotNonBreather
   # DS14-species-emergency-end
   - LoadoutSpeciesVoxNitrogen
   - EmergencyBeerMime
@@ -888,7 +896,7 @@
   - SalvageSpecialistJumpsuitFormal
   - SalvageSpecialistJumpskirt
   - SalvageSpecialistJumpskirtFormal
-  
+
 - type: loadoutGroup
   id: SalvageSpecialistOuterClothing
   name: loadout-group-salvage-specialist-outerclothing

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -99,7 +99,7 @@
   - ChefUnderwear # DS14-Underwear
   - ChefHand # DS14
   - ChefGloves # DS14
-  
+
 - type: roleLoadout
   id: JobLibrarian
   groups:
@@ -150,6 +150,7 @@
   - JanitorGloves
   - CommonBackpack
   - JanitorOuterClothing
+  - JanitorShoes
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -23,7 +23,6 @@
 - type: startingGear
   id: JanitorGear
   equipment:
-    shoes: ClothingShoesGaloshes
     id: JanitorPDA
     ears: ClothingHeadsetService
     belt: ClothingBeltJanitorFilled


### PR DESCRIPTION
## Описание PR
В торгомате уборщика изменены туфли с чёрных на фиолетовые, добавлен светоотражающий жилет. Так же фиолетовые туфли и жилет добавлены для выбора в лоадаут.

## Почему / Зачем / Баланс
По предложению https://discord.com/channels/1030160796401016883/1358363131704905929
На баланс не влияет, уборщики будут счастливы.

## Технические детали
Добавлена новая группа в лоадаут уборщика - обувь, сами же галоши удалены из принудительного стартового снаряжения.

## Медиа
![Content Client_4LFfubdu1q](https://github.com/user-attachments/assets/640496a3-696e-4a19-9f05-3f06b41b3729)
![Content Client_83v5ZvLtpP](https://github.com/user-attachments/assets/79d774d9-f7b5-4e8e-8989-a033fa5db12f)
![Content Client_8Xk9oU72ZM](https://github.com/user-attachments/assets/5e7d9296-ff14-4630-bc41-e79764cf1de6)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет.

**Список изменений**
:cl:
- add: Добавлены фиолетовые туфли и светоотражающий жилет в лоадаут и торгомат уборщика.
