### PR TITLE
Фикс коллизии Блоба

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -35,13 +35,13 @@ public enum CollisionGroup
     SingularityLayer = Opaque | Impassable | MidImpassable | HighImpassable | LowImpassable | BulletImpassable | InteractImpassable | DoorPassable,
 
     // Humanoids, etc.
-    MobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
+    MobMask = Impassable | HighImpassable | MidImpassable | LowImpassable | BlobImpassable, // backmen: blob
     MobLayer = Opaque | BulletImpassable,
     // Mice, drones
-    SmallMobMask = Impassable | LowImpassable,
+    SmallMobMask = Impassable | LowImpassable | BlobImpassable, // backmen: blob
     SmallMobLayer = Opaque | BulletImpassable,
     // Birds/other small flyers
-    FlyingMobMask = Impassable | HighImpassable,
+    FlyingMobMask = Impassable | HighImpassable | BlobImpassable, // backmen: blob
     FlyingMobLayer = Opaque | BulletImpassable,
 
     // start-backmen: blob
@@ -53,11 +53,11 @@ public enum CollisionGroup
     // end-backmen: blob
 
     // Mechs
-    LargeMobMask = Impassable | HighImpassable | MidImpassable | LowImpassable,
+    LargeMobMask = Impassable | HighImpassable | MidImpassable | LowImpassable | BlobImpassable, // backmen: blob
     LargeMobLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable,
 
     // Machines, computers
-    MachineMask = Impassable | MidImpassable | LowImpassable,
+    MachineMask = Impassable | MidImpassable | LowImpassable | BlobImpassable, // backmen: blob
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
@@ -65,11 +65,11 @@ public enum CollisionGroup
     CrateMask = Impassable | HighImpassable | LowImpassable,
 
     // Tables that SmallMobs can go under
-    TableMask = Impassable | MidImpassable,
+    TableMask = Impassable | MidImpassable | BlobImpassable, // backmen: blob
     TableLayer = MidImpassable,
 
     // Tabletop machines, windoors, firelocks
-    TabletopMachineMask = Impassable | HighImpassable,
+    TabletopMachineMask = Impassable | HighImpassable | BlobImpassable, // backmen: blob
     // Tabletop machines
     TabletopMachineLayer = Opaque | BulletImpassable,
 
@@ -82,8 +82,8 @@ public enum CollisionGroup
 
     // Soap, spills
     SlipLayer = MidImpassable | LowImpassable,
-    ItemMask = Impassable | HighImpassable,
-    ThrownItem = Impassable | HighImpassable | BulletImpassable,
+    ItemMask = Impassable | HighImpassable | BlobImpassable, // backmen: blob
+    ThrownItem = Impassable | HighImpassable | BulletImpassable | BlobImpassable, // backmen: blob
     WallLayer = Opaque | Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
     BlobTileLayer = Opaque | BlobImpassable | BulletImpassable, // backmen: blob
     GlassLayer = Impassable | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,


### PR DESCRIPTION
## Описание PR
Меняет группы коллизии, чтобы по блобу не могли бегать всякие уроды

## Почему / Зачем / Баланс
Блоб пуся, которого куканят донат расы

## Тех Штуки
Изменено 9 строчек групп коллизий, куда был вставлено коллизия блоба

**Список изменений**

:cl: no_mad
- fix: Исправлена коллизия блоба
