### PR TITLE
Убран стан борга криком паука

### DIFF
--- a/Content.Server/DeadSpace/Abilities/StanRadius/StanRadiusSystem.cs
+++ b/Content.Server/DeadSpace/Abilities/StanRadius/StanRadiusSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Silicons.Borgs.Components;
 
 namespace Content.Server.DeadSpace.Abilities.StunRadius;
 
@@ -55,9 +56,11 @@ public sealed partial class StunRadiusSystem : EntitySystem
             if (EntityManager.HasComponent<MobStateComponent>(ent))
             {
                 if (component.IgnorAlien && _npcFaction.IsEntityFriendly(uid, ent))
-                {
                     continue;
-                }
+
+                if (HasComp<BorgChassisComponent>(ent) && !component.StunBorg)
+                    continue;
+
                 if (TryComp(ent, out PhysicsComponent? physics))
                 {
                     _physics.SetLinearVelocity(ent, physics.LinearVelocity * component.LaunchForwardsMultiplier, body: physics);

--- a/Content.Shared/DeadSpace/Abilities/StunRadius/Components/StunRadiusComponent.cs
+++ b/Content.Shared/DeadSpace/Abilities/StunRadius/Components/StunRadiusComponent.cs
@@ -37,4 +37,8 @@ public sealed partial class StunRadiusComponent : Component
 
     [DataField("ignorAlien")]
     public bool IgnorAlien = true;
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("stunBorg")]
+    public bool StunBorg = false;
 }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
Убран стан борга криком паука

## Почему / Зачем / Баланс
Основано на: https://discord.com/channels/1030160796401016883/1138194012575113297/threads/1377598561960726568
Логично

## Технические детали
Добавил поле StunBorg в StunRadiusComponent, изначально false, которое определяет, надо ли станить боргов этой абилкой.
Фикс распространяется и на стан пауками, и демоном-клоуном (если надо, чтобы демон станил боргов, можно подредачить у них в ymlке. Я подумал, что они тоже не должны станить боргов)

## Медиа
Не

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Не

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- tweak: Убран стан боргов криком пауков
