### PR TITLE
Добавлена возможность одних вкусов подавлять другие

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FlavorProfileSystem.cs
@@ -70,6 +70,20 @@ public sealed class FlavorProfileSystem : EntitySystem
 
         if (flavors.Count > 1)
         {
+            // DS14-flavor-neutralize-start
+            var neutralized = new List<FlavorPrototype>();
+            foreach (FlavorPrototype flavor in flavors)
+            {
+                foreach (ProtoId<FlavorPrototype> neutralizedProtoId in flavor.Neutralize)
+                {
+                    FlavorPrototype neutralizedProto = _prototypeManager.Index<FlavorPrototype>(neutralizedProtoId);
+                    if (!neutralized.Contains(neutralizedProto))
+                        neutralized.Add(neutralizedProto);
+                }
+            }
+            flavors = flavors.Except(neutralized).ToList();
+            // DS14-flavor-neutralize-end
+
             var lastFlavor = Loc.GetString(flavors[^1].FlavorDescription);
             var allFlavors = string.Join(", ", flavors.GetRange(0, flavors.Count - 1).Select(i => Loc.GetString(i.FlavorDescription)));
             return Loc.GetString("flavor-profile-multiple", ("flavors", allFlavors), ("lastFlavor", lastFlavor));

--- a/Content.Shared/Nutrition/Flavor.cs
+++ b/Content.Shared/Nutrition/Flavor.cs
@@ -13,6 +13,11 @@ public sealed partial class FlavorPrototype : IPrototype
 
     [DataField("description")]
     public string FlavorDescription { get; private set; } = default!;
+
+    // DS14-flavor-neutralize-start
+    [DataField]
+    public List<ProtoId<FlavorPrototype>> Neutralize = new();
+    // DS14-flavor-neutralize-end
 }
 
 public enum FlavorType : byte

--- a/Resources/Prototypes/Flavors/flavors.yml
+++ b/Resources/Prototypes/Flavors/flavors.yml
@@ -8,11 +8,19 @@
   id: sweet
   flavorType: Base
   description: flavor-base-sweet
+  # DS14-flavor-neutralize-start
+  neutralize:
+    - acid
+  # DS14-flavor-neutralize-end
 
 - type: flavor
   id: salty
   flavorType: Base
   description: flavor-base-salty
+  # DS14-flavor-neutralize-start
+  neutralize:
+    - bitter
+  # DS14-flavor-neutralize-end
 
 - type: flavor
   id: sour
@@ -28,6 +36,10 @@
   id: spicy
   flavorType: Base
   description: flavor-base-spicy
+  # DS14-flavor-neutralize-start
+  neutralize:
+    - medicine
+  # DS14-flavor-neutralize-end
 
 - type: flavor
   id: metallic


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
<!-- Убедитесь, что ваш PR направлен в правильный репозиторий (dead-space-server/space-station-14-fobos, а не в оригинальный space-wizards/space-station-14).   -->

## Описание PR
Добавил возможность одних вкусов подавлять другие. Сладкий вкус нейтрализует кислотный, солёный горький, а острый - вкус медицины.

## Почему / Зачем / Баланс
Расширяет механику вкусов, позволяет отравителям действовать не как low level Штирлиц, подавая еду, которая ощущается на вкус отравленной, а маскировать вкус отравы.

## Технические детали
Нет

## Медиа
Нет

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- add: Добавлена нейтрализация одних вкусов другими
