### PR TITLE
deathsquad hardsuit update

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -754,6 +754,7 @@
         Heat: 0.80
         Radiation: 0.80
         Caustic: 0.95
+        Poison: 0.80 # DS14
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -979,8 +979,11 @@
       coefficients:
         Blunt: 0.2 #best armor in the game
         Slash: 0.2
+        Poison: 0.05 # DS14-value: what is poison?
         Piercing: 0.2
         Heat: 0.1
+        Cold: 0.1
+        Shock: 0.1
         Radiation: 0.05
         Caustic: 0.1
         Stun: 0.05 # DS14-value: what is stun?


### PR DESCRIPTION
## Описание PR
Добавлена защита от яда в скафандр эскадрона смерти + защита от холода и электричества, на всякий, на будущее. 1/3 обновления ЭС (чтобы разделить).

## Почему / Зачем / Баланс
Самые сильные бойцы НТ умирают с двух укусов паука или от фиолетового блоба - не порядок. На баланс влияет в лучшую сторону.

## Технические детали
Изменены прототипы скафандра и шлема скафандра ЭС

## Медиа
![image](https://github.com/user-attachments/assets/2c0ab2ca-68d4-4526-880e-525a02ef7224)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Теперь бойцы эскадрона смерти защищены от воздействия яда на 95%!