### PR TITLE
Фикс паука дрона и связующей паутины

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
@@ -47,7 +47,7 @@
       key_slots: !type:Container
   - type: EncryptionKeyHolder
     keySlots: 1
-    keysExtractionMethod: Destruction
+    keysUnlocked: false
   - type: Appearance
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
@@ -47,6 +47,7 @@
       key_slots: !type:Container
   - type: EncryptionKeyHolder
     keySlots: 1
+    keysExtractionMethod: Destruction
   - type: Appearance
   - type: ContainerFill
     containers:
@@ -83,7 +84,6 @@
     issuer: objective-issuer-spider-terror
   - type: RoleRequirement
     roles:
-      mindRoles:
       - SpiderTerrorRole
 
 - type: entity
@@ -96,7 +96,7 @@
       sprite: _DeadSpace/Spiders/egg.rsi
       state: tomb
   - type: NumberObjective
-    min: 4000
-    max: 4000
+    min: 5000
+    max: 5000
     title: objective-condition-capture-spiderterror-title
   - type: SpiderTerrorConditions

--- a/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/antag.yml
@@ -96,7 +96,7 @@
       sprite: _DeadSpace/Spiders/egg.rsi
       state: tomb
   - type: NumberObjective
-    min: 5000
-    max: 5000
+    min: 4000
+    max: 4000
     title: objective-condition-capture-spiderterror-title
   - type: SpiderTerrorConditions

--- a/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
@@ -575,7 +575,6 @@
     - Biological
   - type: Gun
     fireRate: 1
-    cycleable: false
     useKey: false
     selectedMode: SemiAuto
     availableModes:
@@ -583,6 +582,7 @@
     soundGunshot: /Audio/_DeadSpace/Necromorfs/bluet.ogg
   - type: BallisticAmmoProvider
     proto: BulletAcid
+    cycleable: false
     capacity: 1000
   - type: GhostTakeoverAvailable
 

--- a/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
@@ -575,6 +575,7 @@
     - Biological
   - type: Gun
     fireRate: 1
+    cycleable: false
     useKey: false
     selectedMode: SemiAuto
     availableModes:


### PR DESCRIPTION
## Описание PR
Убрал возможность перезарядить паука дрона и достать ключ шифрования Пауков Ужаса. Вставление себе в гарнитуру не убирал, так как получить ключ всё равно нельзя.

## Почему / Зачем / Баланс
Странно, поэтому убрал. 

## Технические детали
Добавил строчку cycleable: false чтобы заблокировать кнопку "Перезарядить" и заблокировал ключ шифрования у связующей паутины чтобы его нельзя было извлечь. Разрушение связующей паутины или её подрыв ключ не извлекают, как и все типы инструментов.

## Медиа
Не надо.

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нету

**Список изменений**
:cl:
- fix: Паука дрона больше нельзя перезарядить, а из связующей паутины извлечь ключ шифрования Пауков Ужаса.