### PR TITLE
Иммунитет от зомби и некро паучкам жужаса

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
+++ b/Resources/Prototypes/_DeadSpace/Spiders/spiders.yml
@@ -8,6 +8,8 @@
   description: Маленький ядовитый паучок.
   components:
   - type: ImmunEgg
+  - type: ZombieImmune
+  - type: ImmunitetInfectionDead
   - type: Metabolizer
     removeEmpty: true
     solutionOnBody: false


### PR DESCRIPTION
## Описание PR
Добавил два компонента иммунитета базовому прототипу пауков ужаса. Одобрено KloopRee.

## Почему / Зачем / Баланс
Зомбированные пауки ужаса очень сильны, обладают всеми способностями и возможностью эволюционировать, что уберёт заражение. Во благо баланса.

## Технические детали
В прототип BaseMobSpiderTerror добавлены два компонента иммунитета - ZombieImmune и ImmunitetInfectionDead

## Медиа
Не надо

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Теперь пауки ужаса обладают иммунитетом к зомби и некро вирусам.
