### PR TITLE
Хотфикс Ларго

### DIFF
--- a/Resources/Prototypes/_Corvax/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Mobs/NPCs/pets.yml
@@ -48,7 +48,8 @@
     - type: Tag
       tags:
         - CannotSuicide
-    # DS14-start
+      # DS14-start
+        - DoorBumpOpener
     - type: Inventory
       speciesId: gorilla
       templateId: largo

--- a/Resources/Prototypes/_Corvax/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Mobs/NPCs/pets.yml
@@ -48,7 +48,7 @@
     - type: Tag
       tags:
         - CannotSuicide
-      # DS14-start
+    # DS14-start
         - DoorBumpOpener
     - type: Inventory
       speciesId: gorilla


### PR DESCRIPTION
## Описание PR
Добавил DoorBumpOpener, который почему-то потерялся в PR-е на Ларго

## Почему / Зачем / Баланс
Исправление косяка

## Технические детали
Добавил тэг DoorBumpOpener

## Медиа
Не надо

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Ларго научили пользоваться шлюзами - теперь он может их открывать.
