### PR TITLE
Исправление аварийного лоадаута молей и обёрток от ВРП/ИРП

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -304,8 +304,6 @@
           prob: 0.1
         - id: FoodPacketMRETrash
           prob: 0.1
-        - id: FoodPacketFRETrash # DS14
-          prob: 0.1
         - id: FoodPacketPistachioTrash
           prob: 0.1
         - id: FoodPacketSemkiTrash

--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -304,6 +304,8 @@
           prob: 0.1
         - id: FoodPacketMRETrash
           prob: 0.1
+        - id: FoodPacketFRETrash # DS14
+          prob: 0.1
         - id: FoodPacketPistachioTrash
           prob: 0.1
         - id: FoodPacketSemkiTrash

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -689,7 +689,6 @@
           Quantity: 10
   - type: Tag
     tags:
-    - ClothMade
     - Trash
   - type: Sprite
     state: mre-wrapper

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -15,7 +15,6 @@
     - Arachnid
     - Diona
     - Human
-    - Moth
     - Reptilian
     # DS14-species-start
     - Demon

--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Consumable/Food/snacks.yml
@@ -64,7 +64,6 @@
           Quantity: 10
   - type: Tag
     tags:
-    - ClothMade
     - Trash
   - type: Sprite
     sprite: _DeadSpace/Objects/Consumable/Food/snacks.rsi


### PR DESCRIPTION
## Описание PR
Исправил появление обычной аварийной коробки у молей, убрал возможность молькам кушать обёртки.

## Почему / Зачем / Баланс
Исправил свой же косяк. Возможность кушать обёртки убрал нианам за ненадобностью - это был костыль разработчиков, ещё и довольно питательный.

## Технические детали
Удалён тэг еды из ткани у обёрток в /Entities/Objects/Consumable/Food/snacks.yml и /_DeadSpace/Entities/Objects/Consumable/Food/snacks.yml, удалены нианы из списка выдачи обычных аварийных наборов тут /Loadouts/Miscellaneous/survival.yml

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Нианы теперь не могут кушать обёртки от ИРП и ВРП.
- fix: Исправлена выдача обычного аварийного набора нианам. 
