### PR TITLE
Убран шанс на раундстарт колдуна в режимх Юнитологи/Пауки ужаса/Блоб/Зомби

### DIFF
--- a/Resources/Prototypes/_Backmen/game_presets.yml
+++ b/Resources/Prototypes/_Backmen/game_presets.yml
@@ -12,4 +12,4 @@
     - BlobGameMode
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule
+    - SubGamemodesRuleNoWizard # DS14

--- a/Resources/Prototypes/_DeadSpace/game_presets.yml
+++ b/Resources/Prototypes/_DeadSpace/game_presets.yml
@@ -12,7 +12,7 @@
     - Unitology
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule
+    - SubGamemodesRuleNoWizard
 
 - type: gamePreset
   id: SecretUnitology
@@ -28,7 +28,7 @@
     - Unitology
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule
+    - SubGamemodesRuleNoWizard
 
 - type: gamePreset
   id: SpiderTerror
@@ -44,7 +44,7 @@
     - SpiderTerror
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule
+    - SubGamemodesRuleNoWizard
 
 - type: gamePreset
   id: SecretSpiderTerror
@@ -60,4 +60,4 @@
     - SpiderTerror
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule
+    - SubGamemodesRuleNoWizard

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -269,8 +269,8 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
-  - SubGamemodesRule # DS14
-  
+  - SubGamemodesRuleNoWizard # DS14
+
 - type: gamePreset
   id: Zombieteors
   alias:


### PR DESCRIPTION
## Описание PR
Заменён SubGamemodesRule на SubGamemodesRuleNoWizard в режимах юнитологов, пауков ужаса, блобе и зомби. В этих режимах он банально неуместен раундстартом, хоть и шанс на это был не самый большой. Вместо резни с антагонистом раунда - мог прилететь колдун и всех убить. 

## Почему / Зачем / Баланс
Для большего комфорта в вышеописанных режимах. Он всё так же может упасть в расширенном, выживании, предателях и не только.

## Технические детали
Изменены пресеты Unitology, SecretUnitology, SpiderTerror, SecretSpiderTerror, Zombie, Blob

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Маг больше не будет появляться раундстартом в режимах: Юнитологи, Пауки ужаса, Блоб, Зомби.
