### PR TITLE
Исправление отображения модулей борга в руках

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -18,6 +18,23 @@
     - Fulton0
   - type: BorgModuleIcon
     icon: { sprite: /Textures/_DeadSpace/Interface/Actions/actions_borg.rsi, state: adv-mining-module }
+  - type: Item
+    sprite: Objects/Specific/Robotics/borgmodule.rsi
+    inhandVisuals:
+      left:
+      - state: base-icon-inhand-left
+        color: "#EBD8B7"
+      - state: base-module-inhand-left
+        color: "#613D1D"
+      - state: base-stripes-inhand-left
+        color: "#593718"
+      right:
+      - state: base-icon-inhand-right
+        color: "#EBD8B7"
+      - state: base-module-inhand-right
+        color: "#613D1D"
+      - state: base-stripes-inhand-right
+        color: "#593718"
 
 - type: entity
   id: BorgModuleMiningWeapon
@@ -35,3 +52,20 @@
     - WeaponCrusherDagger
   - type: BorgModuleIcon
     icon: { sprite: /Textures/_DeadSpace/Interface/Actions/actions_borg.rsi, state: pka-mining-module }
+  - type: Item
+    sprite: Objects/Specific/Robotics/borgmodule.rsi
+    inhandVisuals:
+      left:
+      - state: base-icon-inhand-left
+        color: "#EBD8B7"
+      - state: base-module-inhand-left
+        color: "#613D1D"
+      - state: base-stripes-inhand-left
+        color: "#593718"
+      right:
+      - state: base-icon-inhand-right
+        color: "#EBD8B7"
+      - state: base-module-inhand-right
+        color: "#613D1D"
+      - state: base-stripes-inhand-right
+        color: "#593718"

--- a/Resources/Prototypes/_DeadSpace/security_borg.yml
+++ b/Resources/Prototypes/_DeadSpace/security_borg.yml
@@ -247,7 +247,7 @@
     inhandVisuals:
       left:
       - state: base-icon-inhand-left
-        color: "#326496"
+        color: "#EBD8B7"
       - state: base-module-inhand-left
         color: "#34476c"
       - state: base-part-inhand-left
@@ -255,7 +255,7 @@
         color: "#404040"
       right:
       - state: base-icon-inhand-right
-        color: "#326496"
+        color: "#EBD8B7"
       - state: base-module-inhand-right
         color: "#34476c"
       - state: base-part-inhand-right

--- a/Resources/Prototypes/_DeadSpace/security_borg.yml
+++ b/Resources/Prototypes/_DeadSpace/security_borg.yml
@@ -242,9 +242,28 @@
   parent: BaseBorgModule
   abstract: true
   components:
-    - type: Tag
-      tags:
-        - BorgModuleSecurity
+  - type: Item
+    sprite: Objects/Specific/Robotics/borgmodule.rsi
+    inhandVisuals:
+      left:
+      - state: base-icon-inhand-left
+        color: "#326496"
+      - state: base-module-inhand-left
+        color: "#34476c"
+      - state: base-part-inhand-left
+      - state: base-stripes-inhand-left
+        color: "#404040"
+      right:
+      - state: base-icon-inhand-right
+        color: "#326496"
+      - state: base-module-inhand-right
+        color: "#34476c"
+      - state: base-part-inhand-right
+      - state: base-stripes-inhand-right
+        color: "#404040"
+  - type: Tag
+    tags:
+    - BorgModuleSecurity
 
 - type: entity
   name: челюсти жизни киборга СБ


### PR DESCRIPTION
## Описание PR
Исправил отображение спрайтов в руках у всех модулей борга СБ и у своих шахтёрских модулей, теперь нет большой еррорки в руках.

## Почему / Зачем / Баланс
Исправление под обновление остальных модулей

## Технические детали
Изменены прототипы в _DeadSpace/security_borg.yml и _DeadSpace/Entities/Objects/Specific/Robotics/borg_modules.yml, использованы стандартные спрайты, чтобы не плодить лишние файлы

## Медиа
![image](https://github.com/user-attachments/assets/9e706be8-494b-444b-86e1-ff25f2e0f044)

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Исправлено отображение в руках модулей борга СБ, утилизаторского оружейного и продвинутого шахтёрского.
