### PR TITLE
Исправление шавухи

### DIFF
--- a/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
+++ b/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
@@ -26,6 +26,9 @@
           Quantity: 3
   - type: Item
     sprite: _ADT/Objects/Consumable/Food/shawerma.rsi
+  - type: Tag
+    tags:
+    - Meat
 
 - type: entity
   name: шаурма

--- a/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
+++ b/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
@@ -26,7 +26,7 @@
           Quantity: 3
   - type: Item
     sprite: _ADT/Objects/Consumable/Food/shawerma.rsi
-  - type: Tag
+  - type: Tag # DS14
     tags:
     - Meat
 

--- a/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
+++ b/Resources/Prototypes/_ADT/Entities/Objects/Consumable/Food/shawerma.yml
@@ -26,7 +26,7 @@
           Quantity: 3
   - type: Item
     sprite: _ADT/Objects/Consumable/Food/shawerma.rsi
-  - type: Tag # DS14
+  - type: Tag
     tags:
     - Meat
 


### PR DESCRIPTION
## Описание PR
Добавил тэг Meat базовой шаурме - теперь все плотоядные расы могут ею питаться

## Почему / Зачем / Баланс
Исправление недоработки, по просьбам в предложке и багах. На баланс не влияет

## Технические детали
Добавил компонент Tag и сам тэг Meat в прототипе _ADT/Entities/Objects/Consumable/Food/shawerma.yml

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- fix: Теперь все плотоядные расы могут кушать шаурму.
