### PR TITLE
Группы кастомным рецептам еды, обновление рецепта круассанов

### DIFF
--- a/Resources/Prototypes/_ADT/Recipes/Cooking/croissant_recipe.yml
+++ b/Resources/Prototypes/_ADT/Recipes/Cooking/croissant_recipe.yml
@@ -3,23 +3,25 @@
   name: croissant with cream recipe
   result: ADTFoodCroissantCream
   time: 10
+  group: Dessert
   reagents:
     Egg: 6
     Sugar: 5
     Cream: 5
   solids:
-    FoodDoughSlice: 1
+    FoodCroissantRaw: 1
 
 - type: microwaveMealRecipe
   id: ADTFoodCroissantChocolateRecipe
   name: croissant with chocolate recipe
   result: ADTFoodCroissantChocolate
   time: 10
+  group: Dessert
   reagents:
     Egg: 6
     Sugar: 5
   solids:
-    FoodDoughSlice: 1
+    FoodCroissantRaw: 1
     FoodSnackChocolateBar: 1
 
 - type: microwaveMealRecipe
@@ -27,11 +29,12 @@
   name: croissant with cheese recipe
   result: ADTFoodCroissantCheese
   time: 10
+  group: Dessert
   reagents:
     Egg: 6
     Sugar: 5
   solids:
-    FoodDoughSlice: 1
+    FoodCroissantRaw: 1
     FoodCheeseSlice: 1
 
 - type: microwaveMealRecipe
@@ -39,6 +42,7 @@
   name: hot dog
   result: ADTFoodHotDog
   time: 10
+  group: Savory
   reagents:
     Ketchup: 2
   solids:
@@ -50,6 +54,7 @@
   name: pig blanket
   result: FoodMealPigblanket
   time: 5
+  group: Savory
   solids:
     FoodDoughSlice: 1
     ADTFoodSausageRaw: 1

--- a/Resources/Prototypes/_ADT/Recipes/Cooking/fried_egg_recipe.yml
+++ b/Resources/Prototypes/_ADT/Recipes/Cooking/fried_egg_recipe.yml
@@ -3,6 +3,7 @@
   name: fried egg with sausage recipe
   result: ADTFriedEggSausage
   time: 10
+  group: Breakfast
   reagents:
     Egg: 12
   solids:

--- a/Resources/Prototypes/_ADT/Recipes/Cooking/sausage_recipe.yml
+++ b/Resources/Prototypes/_ADT/Recipes/Cooking/sausage_recipe.yml
@@ -3,6 +3,7 @@
   name: raw sausage recipe
   result: ADTFoodSausageRaw
   time: 10
+  group: Savory
   solids:
     FoodMeatCutlet: 1
   reagents:
@@ -15,5 +16,6 @@
   name: fried sausage recipe
   result: ADTFoodSausageFried
   time: 5
+  group: Savory
   solids:
     ADTFoodSausageRaw: 1

--- a/Resources/Prototypes/_ADT/Recipes/Cooking/shawerma_recipe.yml
+++ b/Resources/Prototypes/_ADT/Recipes/Cooking/shawerma_recipe.yml
@@ -3,6 +3,7 @@
   name: shawerma recipe
   result: ADTShawermaDefault
   time: 20
+  group: Savory
   solids:
     FoodTomato: 1
     FoodMeatCutlet: 3
@@ -18,6 +19,7 @@
   name: cheese shawerma recipe
   result: ADTShawermaCheese
   time: 20
+  group: Savory
   solids:
     FoodTomato: 1
     FoodMeatCutlet: 3
@@ -34,6 +36,7 @@
   name: shawerma recipe
   result: ADTShawermaMeat
   time: 20
+  group: Savory
   solids:
     FoodMeatCutlet: 3
     FoodMeatCooked: 1

--- a/Resources/Prototypes/_Corvax/Recipes/Cooking/meat_recipes.yml
+++ b/Resources/Prototypes/_Corvax/Recipes/Cooking/meat_recipes.yml
@@ -3,6 +3,7 @@
   name: pelmeni recipe
   result: FoodPelmeniBowl
   time: 10
+  group: Savory
   reagents:
     Water: 20
   solids:

--- a/Resources/Prototypes/_DeadSpace/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_DeadSpace/Recipes/Cooking/meal_recipes.yml
@@ -3,6 +3,7 @@
   name: lasanga recipe
   result: Lasanga
   time: 20
+  group: Savory
   solids:
     FoodTomato: 1
     FoodMeat: 1
@@ -16,6 +17,7 @@
   name: notsandwich recipe
   result: NotSandwich
   time: 10
+  group: Savory
   solids:
     ClothingMaskItalianMoustache: 1
     FoodBreadPlainSlice: 2
@@ -25,6 +27,7 @@
   name: chawanmushi recipe
   result: Chawanmushi
   time: 15
+  group: Savory
   reagents:
     Milk: 5
     Egg: 10
@@ -35,6 +38,7 @@
   name: bone soup recipe
   result: FoodSoupBone
   time: 10
+  group: Soup
   reagents:
     Water: 10
   solids:
@@ -46,6 +50,7 @@
   name: bone soup recipe
   result: FoodSoupBone
   time: 10
+  group: Soup
   reagents:
     Water: 10
   solids:
@@ -57,6 +62,7 @@
   name: bone soup recipe
   result: FoodSoupBone
   time: 10
+  group: Soup
   reagents:
     Water: 10
   solids:
@@ -68,6 +74,7 @@
   name: bone soup recipe
   result: FoodSoupBone
   time: 10
+  group: Soup
   reagents:
     Water: 10
   solids:
@@ -79,6 +86,7 @@
   name: sawdust soup recipe
   result: FoodSoupSawdust
   time: 20
+  group: Soup
   reagents:
     Water: 30
     Cellulose: 20
@@ -90,6 +98,7 @@
   name: caviar burger recipe
   result: FoodCaviarBurger
   time: 5
+  group: Savory
   solids:
     FoodBreadPlainSlice: 1
     FoodCaviar: 1
@@ -99,6 +108,7 @@
   name: honey cake recipe
   result: FoodHoneyCake
   time: 15
+  group: Cake
   reagents:
     Sugar: 20
   solids:
@@ -109,6 +119,7 @@
   name: megasandwich recipe
   result: FoodMegaSandwich
   time: 15
+  group: Savory
   reagents:
     Mayo: 10
   solids:
@@ -123,6 +134,7 @@
   name: mashed potatoes recipe
   result: MashedPotatoes
   time: 20
+  group: Savory
   reagents:
     Milk: 10
   solids:


### PR DESCRIPTION
## Описание PR
Прописал группы всем кастомным (корвакс, адт, дедспейс) рецептам, чтобы они корректно отображались в соответствующей категории рецептов блюд в гайдбуке. Попутно обновил рецепт круассанов, добавив вместо теста - сырой круассан (рецепт делали когда такого ещё не изобрели оффы)

## Почему / Зачем / Баланс
Правки старых рецептов для большей актуальности. На баланс не влияет

## Технические детали
Затронул все рецепты вне пространства оффов, не помечал # DS14 (но могу)

## Медиа
Не требуется

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Изменены рецепты сливочного, шоколадного и сырного круассанов. 
