### PR TITLE
Правка режима Блоба: Требование онлайна (в целом требования режима)

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -42,6 +42,7 @@
     - id: WizardSpawn
     - id: ShadowDemonInvasion
     - id: DemonsInvasion
+    - id: BlobSpawn # DS14-Backmen why we dont use this?
 
 - type: entity
   id: BaseStationEvent

--- a/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Backmen/GameRules/roundstart.yml
@@ -3,7 +3,28 @@
   parent: BaseGameRule
   categories: [ HideSpawnMenu ]
   components:
-  - type: BlobGameRule
+  - type: GameRule
+    minPlayers: 40
+    delay: # 7-10 minutes
+      min: 420
+      max: 600
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Blob ]
+      min: 1
+      max: 2
+      playerRatio: 60 #players = 2 blobs
+      allowNonHumans: true
+      components:
+      - type: BlobCarrier
+      blacklist:
+        components:
+        - AntagImmune
+      briefing:
+        text: blob-carrier-role-greeting
+        color: Plum
+      mindRoles:
+      - MindRoleBlob
 
 - type: entity
   id: Blob


### PR DESCRIPTION
## Описание PR
Доработан BlobGameMode - адекватное требование к онлайну (сейчас отсутствует), задержка выдачи роли, настройка количества блобов в зависимости от игроков, красивое приветствие (без звука на основе ТТС, звучит не очень). Под шумок добавил блоба в мидраунд антагонистов наравне с колдуном, теневым демоном и остальными - он уже настроен, от 40 онлайна, от 20 минуты. Как мидраунд он должен быть интересным, исходя из опыта спавна. Проверил на локалке - требования работают, роль выдаётся.

## Почему / Зачем / Баланс
Исправление серьёзной недоработки или же не до конца перенесённых механик блоба. 

## Технические детали
Пофиксил BlobGameMode в _Backmen/GameRules/roundstart.yml
Добавил BlobSpawn в Resources/Prototypes/GameRules/events.yml

## Медиа
<img width="864" height="332" alt="image" src="https://github.com/user-attachments/assets/f3b98ceb-c088-4231-9e0d-d1809176f032" />

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- add: Блоб теперь может быть мидраунд-антагонистом наравне с теневым демоном и колдуном.
- fix: Исправлен режим Блоба: Добавлено требование 40 игроков для запуска.
