### PR TITLE
Переработка SyndieEvacPod под антагонистов

### DIFF
--- a/Resources/Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml
@@ -15,8 +15,8 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      desc: Evacuation pod
-      name: Evacuation pod
+      desc: GX-Fighter
+      name: GX-Fighter
     - type: Transform
     - type: MapGrid
       chunks:
@@ -238,6 +238,13 @@ entities:
     components:
     - type: Transform
       pos: 1.5,1.5
+      parent: 1
+- proto: BoxFolderNuclearCodes
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -0.39414135,1.46875
       parent: 1
 - proto: CableApcExtension
   entities:
@@ -549,31 +556,6 @@ entities:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-- proto: CrateEmergencyInternals
-  entities:
-  - uid: 192
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
 - proto: CrateSyndicate
   entities:
   - uid: 92
@@ -619,6 +601,13 @@ entities:
           showEnts: False
           occludes: True
           ent: null
+- proto: CrateSyndicateSurplusBundle
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
 - proto: CyberPen
   entities:
   - uid: 93
@@ -628,18 +617,13 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: FaxMachineBase
+- proto: FaxMachineSyndie
   entities:
-  - uid: 162
+  - uid: 90
     components:
-    - type: MetaData
-      desc: syndicate long range fax machine
-      name: syndicate long range fax machine
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-    - type: FaxMachine
-      name: syndicate long range fax machine
 - proto: GasPassiveVent
   entities:
   - uid: 108
@@ -1015,6 +999,13 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+- proto: PhoneInstrumentSyndicate
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.7221788,1.84375
+      parent: 1
 - proto: PlasmaWindowDiagonal
   entities:
   - uid: 70
@@ -1141,22 +1132,24 @@ entities:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-- proto: SyndieVisitorSpawner
+- proto: SyndieSoldierSpawner
   entities:
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
   - uid: 91
     components:
     - type: Transform
       pos: 2.5,1.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+- proto: SyndieSoldierTeamLeaderSpawner
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 0.5,1.5
       parent: 1
 - proto: TableGlass
   entities:

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -21,11 +21,12 @@
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
 
-- type: entityTable
-  id: UnknownShuttlesFreelanceTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
-    children:
-    - id: UnknownShuttleSyndieEvacPod
+# DS14: We don't have freelance shuttles
+#- type: entityTable
+#  id: UnknownShuttlesFreelanceTable
+#  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+#    children:
+#    - id: UnknownShuttleSyndieEvacPod
 
 - type: entityTable
   id: UnknownShuttlesHostileTable
@@ -35,6 +36,7 @@
     - id: UnknownShuttleManOWar
     - id: UnknownShuttleInstigator
     - id: UnknownShuttlePirate # DS14
+    - id: UnknownShuttleSyndieEvacPod # DS14
 
 # Shuttle Game Rules
 
@@ -99,8 +101,12 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    startAnnouncement: null # It should be silent.
-    weight: 5 # lower because weird freelance roles
+    # DS14-start: now they are antags
+    startAnnouncement: null #dont nark on antags
+    weight: 1 #  lower because antags.
+    earliestStart: 20
+    minimumPlayers: 25
+    # DS14-end
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod


### PR DESCRIPTION
## Описание PR
В виду кринжовых наказаний за антагонизм свободным агентам крушения синдиката, а так же из-за постоянного геймплея в пермабриге ибо враги корпорации, изменил спавнеры на шаттле SyndieEvacPod на командира пехоты и двух солдат пехоты - теперь это полноценные антагонисты. Так же изменил аварийный ящик на ящик припасов синдиката, переименованный факс на факс синдиката, а сверху уложил коды от боеголовки и кроваво-красный телефон. Теперь они смогут навести шуму и не будут наказаны за действия антагонистов. Они слабые, но при должном навыке смогут справиться со станцией, но как минимум - привнесут интерес и перчинку в раунд. Консоль связи не делал, ибо места мало, а объяву делать у нас не обязательно - отправят объявление войны факсом, если нужно будет.

## Почему / Зачем / Баланс
По причине неоправданных наказаний и отсутствия интересного геймплея. На баланс особо не повлияет. 

## Технические детали
Был изменён сам шаттл syndie_evacpod, роли жертв крушения синдиката заменены на пехоту, аварийный ящик на припасы, а обычный факс - на факс синдиката. Добавлены коды от ядерки и кроваво-красный телефон. Шаттл переименован в GX-Fighter внутри прототипа.
Не стал менять стандартные роли, делая их антагонистами, ибо они могут пригодиться в дальнейшем - проще использовать уже готовую пехоту.
Закомментирован прототип UnknownShuttlesFreelanceTable, поскольку там был только этот самый шаттл. UnknownShuttleSyndieEvacPod перенесён к остальным вражеским шаттлам в UnknownShuttlesHostileTable.
В прототипе UnknownShuttleSyndieEvacPod добавлено отключение анонса появление, настройка минимального времени и онлайна.

## Медиа
Думаю не требуется, визуальных изменений нет особо.

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Шаттл жертв крушения Синдиката был переработан: Теперь на нём появляется пехота Синдиката (лидер и два солдата). У них есть ящик припасов Синдиката, коды от ядерной боеголовки и огромное желание отомстить за всё время, что они ранее проводили в пермабриге как враги корпорации. Шаттл может появиться после 20 минуты смены при наличии 25 игроков.
