### PR TITLE
Расширение UI новых/обновлённых консолей, перестановка в UI музыкальных инструментов

### DIFF
--- a/Content.Client/Cargo/UI/CargoBountyMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoBountyMenu.xaml
@@ -2,8 +2,8 @@
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'bounty-console-menu-title'}"
-                      SetSize="550 420"
-                      MinSize="400 350">
+                      MinSize="670 450"
+                      SetSize="720 550"> <!-- DeadSpace-Localization -->
     <BoxContainer Orientation="Vertical"
                   VerticalExpand="True"
                   HorizontalExpand="True">

--- a/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
+++ b/Content.Client/Cargo/UI/CargoConsoleMenu.xaml
@@ -1,8 +1,8 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                            xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                           SetSize="600 600"
-                           MinSize="600 600">
+                           MinSize="800 600"
+                           SetSize="800 600"> <!-- DeadSpace-Localization -->
     <BoxContainer Orientation="Vertical" Margin="15 5 15 10">
         <BoxContainer Orientation="Horizontal">
             <Label Text="{Loc 'cargo-console-menu-account-name-label'}"

--- a/Content.Client/CloningConsole/UI/CloningConsoleWindow.xaml
+++ b/Content.Client/CloningConsole/UI/CloningConsoleWindow.xaml
@@ -1,7 +1,7 @@
 <DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc 'comp-pda-ui-menu-title'}"
-            SetSize="400 400"
-            MinSize="400 400">
+            MinSize="600 400"
+            SetSize="600 400"> <!-- DeadSpace-Localization -->
     <TabContainer Name="MasterTabContainer">
         <BoxContainer Name="Scanner"
                       Orientation="Vertical"

--- a/Content.Client/Instruments/UI/InstrumentMenu.xaml
+++ b/Content.Client/Instruments/UI/InstrumentMenu.xaml
@@ -1,30 +1,27 @@
+<!-- DeadSpace-Changes -->
 <DefaultWindow xmlns="https://spacestation14.io"
             xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
     <BoxContainer Orientation="Vertical" SeparationOverride="5">
         <BoxContainer Orientation="Horizontal" VerticalExpand="True">
-            <Button Name="InputButton" ToggleMode="True" Text="{Loc 'instruments-component-menu-input-button'}" TextAlign="Center"
-                    HorizontalExpand="True" SizeFlagsStretchRatio="1" />
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.5" />
-            <Button Name="BandButton" Text="{Loc 'instruments-component-menu-band-button'}" TextAlign="Center" HorizontalExpand="True"
-                    SizeFlagsStretchRatio="1"/>
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.5" />
-            <Button Name="FileButton" Text="{Loc 'instruments-component-menu-play-button'}" TextAlign="Center" HorizontalExpand="True"
-                    SizeFlagsStretchRatio="1" />
+            <Button Name="BandButton" Text="{Loc 'instruments-component-menu-band-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
+            <Button Name="FileButton" Text="{Loc 'instruments-component-menu-play-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" VerticalExpand="True">
-            <Button Name="LoopButton" ToggleMode="True" Text="{Loc 'instruments-component-menu-loop-button'}" TextAlign="Center" HorizontalExpand="True"
-                    SizeFlagsStretchRatio="1" />
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.5" />
-            <Button Name="ChannelsButton" Text="{Loc 'instruments-component-menu-channels-button'}" TextAlign="Center" HorizontalExpand="True"
-                    SizeFlagsStretchRatio="1"/>
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.5" />
-            <Button Name="StopButton" Text="{Loc 'instruments-component-menu-stop-button'}" TextAlign="Center" HorizontalExpand="True"
-                    SizeFlagsStretchRatio="1" />
+            <Button Name="ChannelsButton" Text="{Loc 'instruments-component-menu-channels-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
+            <Button Name="LoopButton" ToggleMode="True" Text="{Loc 'instruments-component-menu-loop-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
+            <Button Name="StopButton" Text="{Loc 'instruments-component-menu-stop-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
+            <Button Name="InputButton" ToggleMode="True" Text="{Loc 'instruments-component-menu-input-button'}"
+                    TextAlign="Center" HorizontalExpand="True" SizeFlagsStretchRatio="2"/>
         </BoxContainer>
         <BoxContainer Orientation="Horizontal" VerticalExpand="True">
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.125" />
-            <Slider Name="PlaybackSlider" HorizontalExpand="True" />
-            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.125" />
+            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.1"/>
+            <Slider Name="PlaybackSlider" HorizontalExpand="True" VerticalAlignment="Center" SizeFlagsStretchRatio="5"/>
+            <Control HorizontalExpand="True" SizeFlagsStretchRatio="0.1"/>
         </BoxContainer>
     </BoxContainer>
     <PanelContainer Name="UnavailableOverlay" Visible="False" MouseFilter="Stop">

--- a/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
+++ b/Content.Client/Instruments/UI/InstrumentMenu.xaml.cs
@@ -48,7 +48,7 @@ namespace Content.Client.Instruments.UI
             PlaybackSlider.OnValueChanged += PlaybackSliderSeek;
             PlaybackSlider.OnKeyBindUp += PlaybackSliderKeyUp;
 
-            MinSize = SetSize = new Vector2(400, 150);
+            MinSize = SetSize = new Vector2(500, 150); // DS14: expanding the interface size for ru localization
         }
 
         public void SetInstrument(Entity<InstrumentComponent> entity)

--- a/Content.Client/Research/UI/ResearchConsoleMenu.xaml
+++ b/Content.Client/Research/UI/ResearchConsoleMenu.xaml
@@ -3,8 +3,8 @@
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       xmlns:customControls="clr-namespace:Content.Client.Administration.UI.CustomControls"
                       Title="{Loc 'research-console-menu-title'}"
-                      MinSize="625 400"
-                      SetSize="760 550"> <!-- Corvax-Localization -->
+                      MinSize="700 400"
+                      SetSize="980 550"> <!-- DeadSpace-Localization -->
     <BoxContainer Orientation="Vertical"
                   HorizontalExpand="True"
                   VerticalExpand="True">

--- a/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
+++ b/Content.Client/Salvage/UI/SalvageJobBoardMenu.xaml
@@ -2,8 +2,8 @@
                       xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'job-board-ui-window-title'}"
-                      SetSize="550 550"
-                      Resizable="False">
+                      Resizable="False"
+                      SetSize="720 550"> <!-- DeadSpace-Localization -->
     <BoxContainer Orientation="Vertical"
                   VerticalExpand="True"
                   HorizontalExpand="True">


### PR DESCRIPTION
## Описание PR
В апстриме менялись многие консоли, из-за локализации много где теперь не помещается текст и выглядит NE OCHE. Расширил интерфейс до нужного размера, чтобы всё было хорошо. Переделал интерфейс музыкальных инструментов заодно.
Конкретика:
Консоль клонирования была обновлена, но изначальное окошко крохотное и не помещает текст
Исследовательская консоль кушала названия технологий, названия веток
Консоль заказов утилизаторов имела крохотное окошко, где текст на кнопках больше самих кнопок
Консоли заказов не показывали кнопки из-за длины названий товаров
Музыкальные инструменты уже сто лет имеют кривой интерфейс, где кнопочки выглядят не красиво. Тут сделал иначе и пересобрал интерфейс, чтобы это выглядело компактно, красиво (внутренний перфекционист доволен) и не слишком громоздко. Тут изображение "до" забыл сделать

## Почему / Зачем / Баланс
Во благо прекрасного. Ничего не ломает, балансу не вредит

## Технические детали
Затронул несколько интерфейсов (xaml), но в музыкальных инструментов из-за вписанного не в xaml размера пришлось трогать и xaml.cs

## Медиа
<img width="1085" height="414" alt="image" src="https://github.com/user-attachments/assets/ca7228df-9571-48f9-b61b-a211dc688a38" />
<img width="1052" height="1220" alt="image" src="https://github.com/user-attachments/assets/48f1ed07-037f-4434-accc-f88fe8a5a170" />
<img width="812" height="1250" alt="image" src="https://github.com/user-attachments/assets/e94d8398-bf5e-440e-944d-07304c867fb9" />
<img width="899" height="1304" alt="image" src="https://github.com/user-attachments/assets/0d6d3d61-5501-4419-ad14-c5476a8e4577" />
<img width="532" height="445" alt="Content Client_NMkvzcPLNn" src="https://github.com/user-attachments/assets/9bd2611b-7154-4892-ae08-633f83216483" />

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Интерфейс музыкальных инструментов переработан, чтобы корректно отображать все кнопки.
