### PR TITLE
Исправление порабощения юнитологами

### DIFF
--- a/Content.Shared/EntityEffects/Effects/CauseEnslavedUnitology.cs
+++ b/Content.Shared/EntityEffects/Effects/CauseEnslavedUnitology.cs
@@ -8,6 +8,7 @@ using Content.Shared.DeadSpace.Necromorphs.Sanity;
 using Content.Shared.DeadSpace.Necromorphs.InfectionDead.Components;
 using Content.Shared.Damage;
 using Content.Shared.Zombies;
+using Content.Shared.Mindshield.Components;
 
 namespace Content.Shared.EntityEffects.Effects;
 
@@ -20,6 +21,11 @@ public sealed partial class CauseEnslavedUnitology : EventEntityEffect<CauseEnsl
     {
         if (!args.EntityManager.HasComponent<MobStateComponent>(args.TargetEntity)
             || !args.EntityManager.HasComponent<HumanoidAppearanceComponent>(args.TargetEntity))
+        {
+            return;
+        }
+
+        if (args.EntityManager.HasComponent<MindShieldComponent>(args.TargetEntity))
         {
             return;
         }

--- a/Resources/Prototypes/_DeadSpace/Necromorphs/uplink.yml
+++ b/Resources/Prototypes/_DeadSpace/Necromorphs/uplink.yml
@@ -119,17 +119,6 @@
   categories:
     - UplinkUnitologyInfection
 
-- type: listing
-  id: UnitologyHypopenBoxList
-  name: Гипоручка
-  description: Ручка с гипоспреем.
-  icon: { sprite: Objects/Storage/penbox.rsi, state: hypopen }
-  productEntity: HypopenBox
-  cost:
-    Telecrystal: 5
-  categories:
-    - UplinkUnitologyInfection
-
 - type: storeCategory
   id: UplinkUnitologyInfection
   name: Общее


### PR DESCRIPTION
## Описание PR
По просьбе KloopRe убрал из аплинка юнитологов гипо и добавил проверку на МШ при порабощении. Больше никаких завербованных ОСЩ

## Почему / Зачем / Баланс
По просьбе https://discord.com/channels/1030160796401016883/1164223291259625532/1412456749398626416

## Технические детали
Добавлена проверка на МШ в Content.Shared/EntityEffects/Effects/CauseEnslavedUnitology.cs

## Медиа
Не надо

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
:cl:
- tweak: Гипоручка была удалена из аплинка юнитологов. Убрана возможность порабощения членов экипажа с имплантом Защиты Разума.
