### PR TITLE
Удаление ссылки на несуществующий интерфейс бекмана

### DIFF
--- a/Content.Client/Backmen/Economy/WageConsole/UI/BonusWageWindow.xaml
+++ b/Content.Client/Backmen/Economy/WageConsole/UI/BonusWageWindow.xaml
@@ -1,7 +1,6 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:ui="clr-namespace:Content.Client.Backmen.Reinforcement.UI"
                       MinWidth="450" MinHeight="200" Title="{Loc wageconsole-bonus-title}">
     <BoxContainer Orientation="Vertical">
         <!-- Data -->

--- a/Content.Client/Backmen/Economy/WageConsole/UI/EditWageRowWindow.xaml
+++ b/Content.Client/Backmen/Economy/WageConsole/UI/EditWageRowWindow.xaml
@@ -1,7 +1,6 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:ui="clr-namespace:Content.Client.Backmen.Reinforcement.UI"
                       MinWidth="450" MinHeight="200" Title="{Loc wageconsole-edit-title}">
     <BoxContainer Orientation="Vertical">
         <!-- Main display -->

--- a/Content.Client/Backmen/Economy/WageConsole/UI/WageConsoleWindow.xaml
+++ b/Content.Client/Backmen/Economy/WageConsole/UI/WageConsoleWindow.xaml
@@ -1,7 +1,6 @@
 ﻿<controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                      xmlns:ui="clr-namespace:Content.Client.Backmen.Reinforcement.UI"
                       MinWidth="600" MinHeight="350" Title="{Loc wageconsole-title}">
     <BoxContainer Orientation="Vertical" HorizontalAlignment="Stretch">
         <!-- Station name -->


### PR DESCRIPTION
## Описание PR
Удалил ссылку на пространство имён бэкмана, так как у нас нет этого в билде. На работоспособность не влияет, но на три ошибки при сборке будет меньше

## Почему / Зачем / Баланс
Фиксик, на баланс не влияет

## Технические детали
Удалены ссылки на Content.Client.Backmen.Reinforcement.UI в интерфейсах бекмана

## Медиа
Не надо

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Нет

**Список изменений**
Не надо
