### PR TITLE
Фикс: Таймеры на гранатах снова показывают секунды

### DIFF
--- a/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
@@ -44,7 +44,7 @@ public sealed partial class TriggerSystem
     private void OnTimerExamined(Entity<TimerTriggerComponent> ent, ref ExaminedEvent args)
     {
         if (args.IsInDetailsRange && ent.Comp.Examinable)
-            args.PushText(Loc.GetString("timer-trigger-examine", ("time", ent.Comp.Delay.TotalSeconds)));
+            args.PushText(Loc.GetString("examine-trigger-timer", ("time", ent.Comp.Delay.TotalSeconds)));
     }
 
     private void OnTimerTriggered(Entity<TimerTriggerComponent> ent, ref TriggerEvent args)
@@ -71,7 +71,7 @@ public sealed partial class TriggerSystem
         args.Verbs.Add(new AlternativeVerb
         {
             Category = TimerOptions,
-            Text = Loc.GetString("timer-trigger-verb-cycle"),
+            Text = Loc.GetString("verb-trigger-timer-cycle"),
             Act = () => CycleDelay(ent, user),
             Priority = 1
         });
@@ -83,7 +83,7 @@ public sealed partial class TriggerSystem
                 args.Verbs.Add(new AlternativeVerb
                 {
                     Category = TimerOptions,
-                    Text = Loc.GetString("timer-trigger-verb-set-current", ("time", option.TotalSeconds)),
+                    Text = Loc.GetString("verb-trigger-timer-set-current", ("time", option.TotalSeconds)),
                     Disabled = true,
                     Priority = -100 * (int)option.TotalSeconds
                 });
@@ -93,13 +93,13 @@ public sealed partial class TriggerSystem
                 args.Verbs.Add(new AlternativeVerb
                 {
                     Category = TimerOptions,
-                    Text = Loc.GetString("timer-trigger-verb-set", ("time", option.TotalSeconds)),
+                    Text = Loc.GetString("verb-trigger-timer-set", ("time", option.TotalSeconds)),
                     Priority = -100 * (int)option.TotalSeconds,
                     Act = () =>
                     {
                         ent.Comp.Delay = option;
                         Dirty(ent);
-                        _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option.TotalSeconds)), user, user);
+                        _popup.PopupClient(Loc.GetString("popup-trigger-timer-set", ("time", option.TotalSeconds)), user, user);
                     }
                 });
             }
@@ -124,7 +124,7 @@ public sealed partial class TriggerSystem
         if (ent.Comp.DelayOptions[^1] <= ent.Comp.Delay)
         {
             ent.Comp.Delay = ent.Comp.DelayOptions[0];
-            _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", ent.Comp.Delay)), ent.Owner, user);
+            _popup.PopupClient(Loc.GetString("popup-trigger-timer-set", ("time", ent.Comp.Delay)), ent.Owner, user);
             return;
         }
 
@@ -133,7 +133,7 @@ public sealed partial class TriggerSystem
             if (option > ent.Comp.Delay)
             {
                 ent.Comp.Delay = option;
-                _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option)), ent.Owner, user);
+                _popup.PopupClient(Loc.GetString("popup-trigger-timer-set", ("time", option)), ent.Owner, user);
                 return;
             }
         }


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->
## Описание PR
<!-- Что вы изменили? -->
Изменены ключи в TriggerSystem.Timer для совпадения с RU-локализацией
## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. -->
Ранее при осмотре гранат писалось "Таймер установлен на  секунд", теперь же "Таймер установлен на x секунд" (где x - количество секунд)
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Ключи в системе и локализации не совпадали, пример:  .ftl - "examine-trigger-timer", TriggerSystem.Timer - "timer-trigger-examine"
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
Не надо
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Нет
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
