### PR TITLE
Фикс щита ренегата

### DIFF
--- a/Content.Server/DeadSpace/Sith/SithShieldAbilitySystem.cs
+++ b/Content.Server/DeadSpace/Sith/SithShieldAbilitySystem.cs
@@ -74,7 +74,7 @@ public sealed class SithShieldAbilitySystem : EntitySystem
             return;
         }
 
-        if (_hands.GetActiveItem(uid) == null)
+        if (_hands.GetActiveItem(uid) != null)
         {
             _popup.PopupEntity(Loc.GetString("Выберете пустую руку!"), uid, uid);
             return;


### PR DESCRIPTION
## Описание PR
После апстрима сломался щит ренегата — по прожатию абилки он перестал выдаваться в пустую руку и триггерился только на занятую. Теперь он снова выдаётся исправно, как было до апстрима.

## Почему / Зачем / Баланс
На баланс влияет положительно, просто возвращает по сути отрезанную у ренегата способность.

## Технические детали
Немного потрогал SithShieldAbilitySystem.cs

## Медиа

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [ ] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Заменил в `if (_hands.GetActiveItem(uid) == null` оператор `==` на `+-`

**Список изменений**
:cl:
- tweak: Исправлен щит ренегата.
