### PR TITLE
Изменение минимального количества игроков для режимов

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -113,7 +113,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 35 # DS14
+    minPlayers: 45 # DS14
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -379,7 +379,7 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 25 # DS14
+    minPlayers: 50 # DS14
     delay:
       min: 600
       max: 900
@@ -495,7 +495,7 @@
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
   - type: GameRule # DS14
-    minPlayers: 15
+    minPlayers: 40 # DS14
 
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,

--- a/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/gamerule.yml
+++ b/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/gamerule.yml
@@ -40,7 +40,7 @@
   id: SiegeOfTheCircle
   components:
   - type: GameRule
-    minPlayers: 65 # DS14
+    minPlayers: 65
   - type: CircleOpsRule
     windowUntilSendObelisk:
       min: 1m

--- a/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/gamerule.yml
+++ b/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/gamerule.yml
@@ -40,7 +40,7 @@
   id: SiegeOfTheCircle
   components:
   - type: GameRule
-    minPlayers: 75
+    minPlayers: 65 # DS14
   - type: CircleOpsRule
     windowUntilSendObelisk:
       min: 1m


### PR DESCRIPTION
## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->
https://discord.com/channels/1030160796401016883/1483027702448525373/1483065439444795413
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
Netu
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Изменение порога игроков для режимов
**Список изменений**
:cl:
- Изменено: Изменён минимальный порог игроков для режимов. Выживание с 40, Зомби с 50, ЯО с 45, Круг с 65


