### PR TITLE
Зомбяки и Некроморфы

### DIFF
--- a/Content.Server/DeadSpace/Necromorphs/InfectionDead/NecromorfSystem.Transform.cs
+++ b/Content.Server/DeadSpace/Necromorphs/InfectionDead/NecromorfSystem.Transform.cs
@@ -319,6 +319,11 @@ public sealed partial class NecromorfSystem
             RemComp(target, handsComp);
         }
 
+        if (TryComp<CuffableComponent>(target, out var cuffs))
+        {
+            RemComp(target, cuffs);
+        }
+
         RemComp<PullerComponent>(target);
 
         var pryComp = EnsureComp<PryingComponent>(target);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -48,6 +48,7 @@ using Content.Server.DeadSpace.Virus.Systems;
 using Content.Server.DeadSpace.Languages;
 using Content.Shared.NPC.Components; // DS14
 using System.Linq; // DS14
+using Content.Shared.Cuffs.Components; // DS14
 using Content.Shared.Temperature.Components;
 
 namespace Content.Server.Zombies;
@@ -335,6 +336,13 @@ public sealed partial class ZombieSystem
             _hands.RemoveHands(target);
             RemComp(target, handsComp);
         }
+
+        // DS14-start
+        if (TryComp<CuffableComponent>(target, out var cuffs))
+        {
+            RemComp(target, cuffs);
+        }
+        // DS14-end
 
         // Sloth: What the fuck?
         // How long until compregistry lmao.


### PR DESCRIPTION
## [Ссылка на задачу](https://discord.com/channels/1030160796401016883/1490695882130194572)
## 
https://github.com/user-attachments/assets/83c85d0e-5022-4322-8828-22cf1335a833

https://github.com/user-attachments/assets/9e697743-71ea-41d3-91b4-c4b99850ff51
## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
## Критических изменений нет
**Список изменений**
:cl:
- Исправлено:  Теперь наручники не мешают зомби и некроморфам атаковать.