### PR TITLE
fix Изменение хитбоксов. Смешарики: Начало

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -230,8 +230,10 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
+        # DS14-start
+          !type:PhysShapeCircle
+          radius: 0.49
+        # DS14-end
         mask:
         - MachineMask
         layer:

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -59,8 +59,10 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.40,-0.40,0.40,0.40"
+        # DS14-start
+          !type:PhysShapeCircle
+          radius: 0.38
+        # DS14-end
         density: 200
         mask:
           - MachineMask

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -281,6 +281,19 @@
     price: 5500 # DS14-uranium-rework
   - type: RadiationBlockingContainer
     resistance: 2
+  # DS14-start
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  # DS14-end
 
 # TODO: need radioactive fallout when destroyed
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -25,8 +25,10 @@
       fixtures:
         fix1:
           shape:
-            !type:PhysShapeAabb
-            bounds: "-0.40,-0.40,0.40,0.40"
+          # DS14-start
+            !type:PhysShapeCircle
+            radius: 0.38
+          # DS14-end
           # Despite the heavy weight, it has wheels, so it's still fairly portable.
           density: 155
           mask:

--- a/Resources/Prototypes/_DeadSpace/Entities/Structures/Decoration/aquarium.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Structures/Decoration/aquarium.yml
@@ -6,6 +6,7 @@
   components:
   - type: Transform
     anchored: true
+    noRot: true
   - type: Physics
     bodyType: Static
   - type: InteractionOutline
@@ -118,6 +119,7 @@
   components:
   - type: Transform
     anchored: true
+    noRot: true
   - type: Physics
     bodyType: Static
   - type: InteractionOutline


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->
https://discord.com/channels/1030160796401016883/1494444447507681423
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
<img width="378" height="234" alt="dotnet_W9RsymbGlq" src="https://github.com/user-attachments/assets/bbaab1e7-ee5c-4e18-9155-146dfc04262e" />

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критических изменений нет
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- Исправлено: РИТЭГи и портативные генераторы всех видов теперь имеют круглый хитбокс и помещаются на криво стоящий шаттл. Ядро ИИ теперь помещается в узкие проходы. Хитбокс аквариума больше не крутится.