### PR TITLE
Сумка для руды/шахтёр юнит/переработчик руды

### DIFF
--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -35,10 +35,10 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
 
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
-        // DeadSpace-start
+        // DS14 start
         SubscribeLocalEvent<MaterialStorageComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
         SubscribeLocalEvent<MaterialStorageComponent, DumpEvent>(OnDump);
-        // DeadSpace-end
+        // DS14 end
         SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
     }
 
@@ -410,7 +410,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
     }
 
-    // DeadSpace-start
+    // DS14 start
     private void OnGetDumpableVerb(EntityUid uid, MaterialStorageComponent component, ref GetDumpableVerbEvent args)
     {
         if (!component.InsertOnInteract)
@@ -439,7 +439,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         args.Handled = true;
         args.PlaySound = inserted;
     }
-    // DeadSpace-end
+    // DS14 end
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)
     {

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -35,10 +35,10 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
 
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
-        // DS14 start
+        // DS14-start
         SubscribeLocalEvent<MaterialStorageComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
         SubscribeLocalEvent<MaterialStorageComponent, DumpEvent>(OnDump);
-        // DS14 end
+        // DS14-end
         SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
     }
 
@@ -410,7 +410,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
     }
 
-    // DS14 start
+    // DS14-start
     private void OnGetDumpableVerb(EntityUid uid, MaterialStorageComponent component, ref GetDumpableVerbEvent args)
     {
         if (!component.InsertOnInteract)
@@ -439,7 +439,7 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         args.Handled = true;
         args.PlaySound = inserted;
     }
-    // DS14 end
+    // DS14-end
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)
     {

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Storage.Components; // DS14
 using Content.Shared.Stacks;
 using Content.Shared.Whitelist;
 using JetBrains.Annotations;
@@ -34,6 +35,10 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
 
         SubscribeLocalEvent<MaterialStorageComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MaterialStorageComponent, InteractUsingEvent>(OnInteractUsing);
+        // DeadSpace-start
+        SubscribeLocalEvent<MaterialStorageComponent, GetDumpableVerbEvent>(OnGetDumpableVerb);
+        SubscribeLocalEvent<MaterialStorageComponent, DumpEvent>(OnDump);
+        // DeadSpace-end
         SubscribeLocalEvent<MaterialStorageComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
     }
 
@@ -404,6 +409,37 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
             return;
         args.Handled = TryInsertMaterialEntity(args.User, args.Used, uid, component);
     }
+
+    // DeadSpace-start
+    private void OnGetDumpableVerb(EntityUid uid, MaterialStorageComponent component, ref GetDumpableVerbEvent args)
+    {
+        if (!component.InsertOnInteract)
+            return;
+
+        args.Verb = Loc.GetString("dump-smartfridge-verb-name", ("unit", uid));
+    }
+
+    private void OnDump(EntityUid uid, MaterialStorageComponent component, ref DumpEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!component.InsertOnInteract)
+            return;
+
+        var inserted = false;
+        foreach (var entity in args.DumpQueue)
+        {
+            if (!TryInsertMaterialEntity(args.User, entity, uid, component))
+                continue;
+
+            inserted = true;
+        }
+
+        args.Handled = true;
+        args.PlaySound = inserted;
+    }
+    // DeadSpace-end
 
     private void OnDatabaseModified(Entity<MaterialStorageComponent> ent, ref TechnologyDatabaseModifiedEvent args)
     {

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,4 +1,8 @@
 using Content.Shared.Inventory;
+// DeadSpace-start
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Silicons.Borgs.Components;
+// DeadSpace-end
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
@@ -13,6 +17,7 @@ public sealed class MagnetPickupSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!; // DS14
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
@@ -49,11 +54,14 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
-            if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
+            // DeadSpace-start
+            if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef) &&
+                (!HasComp<BorgChassisComponent>(xform.ParentUid) || !_hands.TryGetActiveItem((xform.ParentUid, null), out var activeItem) || activeItem != uid))
                 continue;
 
-            if ((slotDef.SlotFlags & comp.SlotFlags) == 0x0)
+            if (slotDef != null && (slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
+            // DeadSpace-end
 
             // No space
             if (!_storage.HasSpace((uid, storage)))

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,8 +1,8 @@
 using Content.Shared.Inventory;
-// DeadSpace-start
+// DS14 start
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Silicons.Borgs.Components;
-// DeadSpace-end
+// DS14 end
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
@@ -54,14 +54,14 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
-            // DeadSpace-start
+            // DS14 start
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef) &&
                 (!HasComp<BorgChassisComponent>(xform.ParentUid) || !_hands.TryGetActiveItem((xform.ParentUid, null), out var activeItem) || activeItem != uid))
                 continue;
 
             if (slotDef != null && (slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
-            // DeadSpace-end
+            // DS14 end
 
             // No space
             if (!_storage.HasSpace((uid, storage)))

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -1,8 +1,8 @@
 using Content.Shared.Inventory;
-// DS14 start
+// DS14-start
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Silicons.Borgs.Components;
-// DS14 end
+// DS14-end
 using Content.Shared.Storage.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Physics.Components;
@@ -54,14 +54,14 @@ public sealed class MagnetPickupSystem : EntitySystem
             comp.NextScan += ScanDelay;
             Dirty(uid, comp);
 
-            // DS14 start
+            // DS14-start
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef) &&
                 (!HasComp<BorgChassisComponent>(xform.ParentUid) || !_hands.TryGetActiveItem((xform.ParentUid, null), out var activeItem) || activeItem != uid))
                 continue;
 
             if (slotDef != null && (slotDef.SlotFlags & comp.SlotFlags) == 0x0)
                 continue;
-            // DS14 end
+            // DS14-end
 
             // No space
             if (!_storage.HasSpace((uid, storage)))

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -33,6 +33,7 @@
   name: integrated ore bag
   description: A large ore bag built into the frame of a mining cyborg.
   components:
+    - type: MagnetPickup # DS14
     - type: Storage
       grid:
       - 0,0,9,5


### PR DESCRIPTION
Теперь руду можно складывать из сумок для руды сразу в печь, шахтёрный юнит теперь автоматически подбирает руду на полу.

## Ссылка на задачу
https://discord.com/channels/1030160796401016883/1500072992028495913

## Медиа
<img width="1252" height="968" alt="image" src="https://github.com/user-attachments/assets/1e6ec3f1-e85d-44da-b220-5c0ecedefa05" />
<img width="980" height="889" alt="image" src="https://github.com/user-attachments/assets/fd287f94-a73b-4bbb-9c68-d4f61c7db54d" />



## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Я ТРОГАЛ КОД ВИЗОВ В СТРАШНЫХ МЕСТАХ!!!!!!

**Список изменений**

:cl:
- Добавлено: Теперь из сумок для руды можно складывать руду сразу в печь.
- Изменено: Теперь утилизаторский юнит автоматически складывает руду в свою сумку.

