### PR TITLE
chore: chattoggle migration

### DIFF
--- a/Content.Server.Database/Migrations/Postgres/20260511120000_BackfillChatToggleAdminFlag.cs
+++ b/Content.Server.Database/Migrations/Postgres/20260511120000_BackfillChatToggleAdminFlag.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Content.Server.Database.Migrations.Postgres
+{
+    [DbContext(typeof(PostgresServerDbContext))]
+    [Migration("20260511120000_BackfillChatToggleAdminFlag")]
+    public class BackfillChatToggleAdminFlag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+INSERT INTO admin_rank_flag (flag, admin_rank_id)
+SELECT 'CHATTOGGLE', server_flags.admin_rank_id
+FROM admin_rank_flag AS server_flags
+WHERE server_flags.flag = 'SERVER'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM admin_rank_flag AS chat_flags
+      WHERE chat_flags.admin_rank_id = server_flags.admin_rank_id
+        AND chat_flags.flag = 'CHATTOGGLE'
+  );
+""");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DELETE FROM admin_rank_flag WHERE flag = 'CHATTOGGLE';");
+        }
+    }
+}

--- a/Content.Server.Database/Migrations/Sqlite/20260511120000_BackfillChatToggleAdminFlag.cs
+++ b/Content.Server.Database/Migrations/Sqlite/20260511120000_BackfillChatToggleAdminFlag.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Content.Server.Database.Migrations.Sqlite
+{
+    [DbContext(typeof(SqliteServerDbContext))]
+    [Migration("20260511120000_BackfillChatToggleAdminFlag")]
+    public class BackfillChatToggleAdminFlag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+INSERT INTO admin_rank_flag (flag, admin_rank_id)
+SELECT 'CHATTOGGLE', server_flags.admin_rank_id
+FROM admin_rank_flag AS server_flags
+WHERE server_flags.flag = 'SERVER'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM admin_rank_flag AS chat_flags
+      WHERE chat_flags.admin_rank_id = server_flags.admin_rank_id
+        AND chat_flags.flag = 'CHATTOGGLE'
+  );
+""");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DELETE FROM admin_rank_flag WHERE flag = 'CHATTOGGLE';");
+        }
+    }
+}


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->
No

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
No

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
No

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
Внутренняя data-migration, исправляет доступ к ранее созданному праву CHATTOGGLE для обладателей права SERVER.

<!--
:cl:
- Добавлено: 
- Удалено: 
- Изменено: 
- Исправлено: 
-->
