### PR TITLE
Скафандровое: Гермавоины страдайте охох мы теперь быстрее 

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -589,6 +589,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
   - type: PointLight
+    radius: 7 #DS-14 start
+    energy: 4 #DS-14 end
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -617,6 +619,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
   - type: PointLight
+    radius: 7 #DS-14 start
+    energy: 4 #DS-14 end
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -641,6 +645,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
   - type: PointLight
+    radius: 7 #DS-14 start
+    energy: 4 #DS-14 end
     color: red
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -674,6 +680,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
   - type: PointLight
+    radius: 7 #DS-14 start
+    energy: 4 #DS-14 end
     color: green
   - type: PressureProtection
     highPressureMultiplier: 0.08
@@ -702,6 +710,8 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/cybersun.rsi
   - type: PointLight # Corvax-Resprite
+    radius: 7 #DS-14 start
+    energy: 4 #DS-14 end
     color: red
   - type: PressureProtection
     highPressureMultiplier: 0.3

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -293,8 +293,8 @@
   - type: StaminaResistance # DS14
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.85 # DS14-value
+    sprintModifier: 0.85 # DS14-value
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -338,8 +338,8 @@
   - type: StaminaResistance
     damageCoefficient: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 0.85 # DS14-value
-    sprintModifier: 0.85 # DS14-value
+    walkModifier: 0.90 # DS14-value
+    sprintModifier: 0.90 # DS14-value
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -378,8 +378,8 @@
   - type: StaminaResistance # DS14
     damageCoefficient: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.8 # DS14-value
-    sprintModifier: 0.8 # DS14-value
+    walkModifier: 0.85 # DS14-value
+    sprintModifier: 0.85 # DS14-value
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitWarden
@@ -614,8 +614,8 @@
   - type: StaminaResistance # DS14
     damageCoefficient: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
@@ -739,6 +739,19 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieMedic
   - type: Tag
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.40 # DS14-value
+        Heat: 0.35 # DS14-value
+        Radiation: 0.5
+        Caustic: 0.5
+  - type: StaminaResistance #
+  - type: ClothingSpeedModifier
+    walkModifier: 0.95 # DS14-value
+    sprintModifier: 0.95 # DS14-value
     tags:
     - Hardsuit
     - WhitelistChameleon
@@ -775,7 +788,7 @@
       coefficients:
         Blunt: 0.6
         Slash: 0.6
-        Piercing: 0.55 # DS14-value
+        Piercing: 0.5 # DS14-value
         Heat: 0.15 # DS14-value
         Radiation: 0.05 # DS14-value
         Caustic: 0.5

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -738,7 +738,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/syndiemedic.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieMedic
-  - type: Tag
   - type: Armor
     modifiers:
       coefficients:
@@ -752,6 +751,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.95 # DS14-value
     sprintModifier: 0.95 # DS14-value
+  - type: Tag
     tags:
     - Hardsuit
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -614,8 +614,8 @@
   - type: StaminaResistance # DS14
     damageCoefficient: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.85 # DS-14 value
+    sprintModifier: 0.85 # DS-14 value
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed

--- a/Resources/Prototypes/_DeadSpace/Entities/Clothing/OuterClothing/pilots.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Clothing/OuterClothing/pilots.yml
@@ -25,7 +25,7 @@
   - type: Clothing
     sprite: _DeadSpace/Clothing/OuterClothing/Hardsuits/pilotsuitsec.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityPilot

--- a/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/hardsuit.yml
+++ b/Resources/Prototypes/_DeadSpace/Necromorphs/TheCircle/hardsuit.yml
@@ -20,8 +20,8 @@
       coefficients:
         Blunt: 0.45
         Slash: 0.4
-        Piercing: 0.35
-        Heat: 0.55
+        Piercing: 0.4
+        Heat: 0.40
         Cold: 0.3
         Radiation: 0.5
         Poison: 0.5
@@ -102,8 +102,8 @@
       coefficients:
         Blunt: 0.3
         Slash: 0.3
-        Piercing: 0.3
-        Heat: 0.5
+        Piercing: 0.35  
+        Heat: 0.3
         Cold: 0.35
         Radiation: 0.25
         Poison: 0.25
@@ -185,7 +185,7 @@
         Blunt: 0.65
         Slash: 0.55
         Piercing: 0.65
-        Heat: 0.65
+        Heat: 0.45
         Cold: 0.6
         Radiation: 0.55
         Poison: 0.5


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
По зову сердца

## Медиа
<img width="911" height="489" alt="изображение" src="https://github.com/user-attachments/assets/59bfec2b-b622-4f1d-bdec-25549a7d52d5" />
Скрин был сделан под шансон

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Не

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- Изменено: Все скафандры СБ стали немного легче (на 5%)
- Изменено: Фонарики на шлемах скафандров ядерных оперативников стали значительно лучше.
- Изменено: Изменены характеристики скафандра медика ЯО: 5% замедления, 60% уколов и 65% термических (было 10% замедления, 65 уколов и 55 термических)
- Изменено: У элитного скафандра ЯО повышено сопротивления уколам до 50% (было 45%)
- Изменено: Ребаланс скафандров Отряда "Круг". Уколы/терма: Кардинал 65 45 -> 60 60. Диакон 70 50 -> 65 70. Гермес 35 35 -> 35 55

