### PR TITLE
#баги fixes

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -197,8 +197,18 @@ public sealed partial class GunSystem : SharedGunSystem
             return;
         }
 
-        // Define target coordinates relative to gun entity, so that network latency on moving grids doesn't fuck up the target location.
-        var coordinates = TransformSystem.ToCoordinates(entity, mousePos);
+        // Keep aim coordinates in the map/grid frame instead of the player's frame.
+        // The player rotates in combat mode, so player-relative aim can be replayed by the
+        // server with a different rotation under latency and send shots sideways or backwards.
+        EntityCoordinates coordinates;
+        if (MapManager.TryFindGridAt(mousePos, out var gridUid, out _))
+        {
+            coordinates = TransformSystem.ToCoordinates(gridUid, mousePos);
+        }
+        else
+        {
+            coordinates = TransformSystem.ToCoordinates(_maps.GetMap(mousePos.MapId), mousePos);
+        }
 
         NetEntity? target = null;
         if (_state.CurrentState is GameplayStateBase screen)

--- a/Content.Server/Chemistry/TileReactions/CleanDecalsReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/CleanDecalsReaction.cs
@@ -28,7 +28,7 @@ public sealed partial class CleanDecalsReaction : ITileReaction
         IEntityManager entityManager,
         List<ReagentData>? data)
     {
-        if (reactVolume <= CleanCost ||
+        if (reactVolume < CleanCost ||
             !entityManager.TryGetComponent<MapGridComponent>(tile.GridUid, out var grid) ||
             !entityManager.TryGetComponent<DecalGridComponent>(tile.GridUid, out var decalGrid))
         {

--- a/Content.Server/Chemistry/TileReactions/ReplaceTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/ReplaceTileReaction.cs
@@ -1,0 +1,49 @@
+using Content.Shared.Chemistry.Reaction;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server.Chemistry.TileReactions;
+
+/// <summary>
+/// Replaces specific tiles when a reagent reacts with them.
+/// </summary>
+[DataDefinition]
+public sealed partial class ReplaceTileReaction : ITileReaction
+{
+    [DataField(required: true)]
+    public Dictionary<string, string> Replacements = new();
+
+    [DataField]
+    public FixedPoint2 Cost = FixedPoint2.New(0.25f);
+
+    public FixedPoint2 TileReact(
+        TileRef tile,
+        ReagentPrototype reagent,
+        FixedPoint2 reactVolume,
+        IEntityManager entityManager,
+        List<ReagentData>? data)
+    {
+        if (reactVolume < Cost ||
+            tile.Tile.IsEmpty ||
+            !entityManager.TryGetComponent<MapGridComponent>(tile.GridUid, out var grid))
+        {
+            return FixedPoint2.Zero;
+        }
+
+        var tileDefs = IoCManager.Resolve<ITileDefinitionManager>();
+        if (!tileDefs.TryGetDefinition(tile.Tile.TypeId, out var current) ||
+            !Replacements.TryGetValue(current.ID, out var replacementId) ||
+            !tileDefs.TryGetDefinition(replacementId, out var replacement))
+        {
+            return FixedPoint2.Zero;
+        }
+
+        var map = entityManager.System<SharedMapSystem>();
+        var variant = tile.Tile.Variant < replacement.Variants ? tile.Tile.Variant : (byte) 0;
+        map.SetTile(tile.GridUid, grid, tile.GridIndices, new Tile(replacement.TileId, tile.Tile.Flags, variant, tile.Tile.RotationMirroring));
+
+        return Cost;
+    }
+}

--- a/Content.Server/DeadSpace/Lavaland/Components/LavalandBubblegumComponent.cs
+++ b/Content.Server/DeadSpace/Lavaland/Components/LavalandBubblegumComponent.cs
@@ -146,6 +146,12 @@ public sealed partial class LavalandBubblegumComponent : Component
     public int CloneCriticalCount = 3;
 
     [DataField]
+    public int MaxActiveClones = 8;
+
+    [DataField]
+    public TimeSpan CriticalCloneCooldown = TimeSpan.FromSeconds(2.5);
+
+    [DataField]
     public int CloneMinOffset = 2;
 
     [DataField]
@@ -332,4 +338,5 @@ public sealed class LavalandBubblegumCloneCharge
     public int RemainingSteps;
     public TimeSpan NextStep;
     public DamageSpecifier? ChargeDamage;
+    public readonly HashSet<EntityUid> HitEntities = new();
 }

--- a/Content.Server/DeadSpace/Lavaland/LavalandAshDrakeSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandAshDrakeSystem.cs
@@ -48,6 +48,9 @@ public sealed class LavalandAshDrakeSystem : EntitySystem
     private readonly Dictionary<Vector2i, DamageSpecifier> _detonatingDamage = new();
     private readonly HashSet<Vector2i> _detonatingIgniteTiles = new();
     private readonly HashSet<EntityUid> _fireTileEntities = new();
+    private readonly HashSet<EntityUid> _tileEntities = new();
+    private readonly HashSet<EntityUid> _damagedEntities = new();
+    private readonly HashSet<Vector2i> _cageFireTiles = new();
 
     public override void Initialize()
     {
@@ -584,44 +587,62 @@ public sealed class LavalandAshDrakeSystem : EntitySystem
         EntityUid gridUid,
         MapGridComponent grid)
     {
-        var interiorFireTiles = new HashSet<Vector2i>();
+        _cageFireTiles.Clear();
         foreach (var entity in drake.CageInteriorEntities)
         {
             if (!Exists(entity) || !TryComp(entity, out TransformComponent? fxform))
                 continue;
-            interiorFireTiles.Add(_map.LocalToTile(gridUid, grid, fxform.Coordinates));
+
+            _cageFireTiles.Add(_map.LocalToTile(gridUid, grid, fxform.Coordinates));
         }
 
         var half = drake.CageHalfSize;
-        var innerHalf = half - 1;
         var center = drake.CageCenter;
+        _damagedEntities.Clear();
 
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        foreach (var fireTile in _cageFireTiles)
         {
-            if (uid == boss ||
-                mobState.CurrentState == MobState.Dead ||
-                xform.GridUid != gridUid)
+            _tileEntities.Clear();
+            _lookup.GetLocalEntitiesIntersecting(
+                gridUid,
+                fireTile,
+                _tileEntities,
+                flags: LookupFlags.Dynamic | LookupFlags.Sundries,
+                gridComp: grid);
+
+            foreach (var uid in _tileEntities)
             {
-                continue;
+                if (uid == boss ||
+                    !_damagedEntities.Add(uid) ||
+                    !TryComp(uid, out DamageableComponent? damageable) ||
+                    !TryComp(uid, out MobStateComponent? mobState) ||
+                    mobState.CurrentState == MobState.Dead ||
+                    !TryComp(uid, out TransformComponent? xform) ||
+                    xform.GridUid != gridUid)
+                {
+                    continue;
+                }
+
+                var tile = _map.LocalToTile(gridUid, grid, xform.Coordinates);
+                var dx = Math.Abs(tile.X - center.X);
+                var dy = Math.Abs(tile.Y - center.Y);
+
+                if (tile != fireTile ||
+                    dx > half ||
+                    dy > half)
+                {
+                    continue;
+                }
+
+                _damageable.TryChangeDamage((uid, damageable), drake.CageInteriorFireDamage, origin: boss);
+                IgniteEntity(uid, drake, boss);
+                _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-6f));
             }
-
-            var tile = _map.LocalToTile(gridUid, grid, xform.Coordinates);
-            var dx = Math.Abs(tile.X - center.X);
-            var dy = Math.Abs(tile.Y - center.Y);
-
-            if (dx > half || dy > half)
-                continue;
-
-            var onBorder = dx == half || dy == half; 
-
-            if (!interiorFireTiles.Contains(tile))
-                continue;
-
-            _damageable.TryChangeDamage((uid, damageable), drake.CageInteriorFireDamage, origin: boss);
-            IgniteEntity(uid, drake, boss);
-            _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-6f));
         }
+
+        _tileEntities.Clear();
+        _damagedEntities.Clear();
+        _cageFireTiles.Clear();
     }
 
     private static Vector2i GetCageCenter(LavalandBossArenaComponent arena, Vector2i target, int halfSize)
@@ -1060,34 +1081,47 @@ public sealed class LavalandAshDrakeSystem : EntitySystem
         EntityUid gridUid,
         MapGridComponent grid)
     {
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        _damagedEntities.Clear();
+
+        foreach (var tile in _detonatingTiles)
         {
-            if (uid == boss ||
-                mobState.CurrentState == MobState.Dead ||
-                xform.GridUid != gridUid)
-            {
+            if (!_detonatingDamage.TryGetValue(tile, out var damage))
                 continue;
-            }
-            var tile = _map.LocalToTile(gridUid, grid, xform.Coordinates);
 
-            if (_detonatingTiles.Contains(tile))
+            _tileEntities.Clear();
+            _lookup.GetLocalEntitiesIntersecting(
+                gridUid,
+                tile,
+                _tileEntities,
+                flags: LookupFlags.Dynamic | LookupFlags.Sundries,
+                gridComp: grid);
+
+            foreach (var uid in _tileEntities)
             {
+                if (uid == boss ||
+                    !_damagedEntities.Add(uid) ||
+                    !TryComp(uid, out DamageableComponent? damageable) ||
+                    !TryComp(uid, out MobStateComponent? mobState) ||
+                    mobState.CurrentState == MobState.Dead ||
+                    !TryComp(uid, out TransformComponent? xform) ||
+                    xform.GridUid != gridUid ||
+                    _map.LocalToTile(gridUid, grid, xform.Coordinates) != tile)
+                {
+                    continue;
+                }
+
                 IgniteEntity(uid, drake, boss);
+                _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
+
+                if (_detonatingIgniteTiles.Contains(tile))
+                    IgniteEntity(uid, drake, boss);
+
+                _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-6f));
             }
-
-            if (!_detonatingTiles.Contains(tile) ||
-                !_detonatingDamage.TryGetValue(tile, out var damage))
-            {
-                continue;
-            }
-
-            _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
-            if (_detonatingIgniteTiles.Contains(tile))
-                IgniteEntity(uid, drake, boss);
-
-            _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-6f));
         }
+
+        _tileEntities.Clear();
+        _damagedEntities.Clear();
     }
 
     private void DamageArea(
@@ -1101,36 +1135,59 @@ public sealed class LavalandAshDrakeSystem : EntitySystem
         bool ignite,
         bool throwTargets)
     {
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        _damagedEntities.Clear();
+
+        for (var x = center.X - radius; x <= center.X + radius; x++)
         {
-            if (uid == boss ||
-                mobState.CurrentState == MobState.Dead ||
-                xform.GridUid != gridUid)
+            for (var y = center.Y - radius; y <= center.Y + radius; y++)
             {
-                continue;
+                var tile = new Vector2i(x, y);
+                if (ChebyshevDistance(center, tile) > radius)
+                    continue;
+
+                _tileEntities.Clear();
+                _lookup.GetLocalEntitiesIntersecting(
+                    gridUid,
+                    tile,
+                    _tileEntities,
+                    flags: LookupFlags.Dynamic | LookupFlags.Sundries,
+                    gridComp: grid);
+
+                foreach (var uid in _tileEntities)
+                {
+                    if (uid == boss ||
+                        !_damagedEntities.Add(uid) ||
+                        !TryComp(uid, out DamageableComponent? damageable) ||
+                        !TryComp(uid, out MobStateComponent? mobState) ||
+                        mobState.CurrentState == MobState.Dead ||
+                        !TryComp(uid, out TransformComponent? xform) ||
+                        xform.GridUid != gridUid ||
+                        _map.LocalToTile(gridUid, grid, xform.Coordinates) != tile)
+                    {
+                        continue;
+                    }
+
+                    _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
+
+                    if (ignite)
+                        IgniteEntity(uid, drake, boss);
+
+                    if (throwTargets)
+                    {
+                        var direction = new Vector2(tile.X - center.X, tile.Y - center.Y);
+                        if (direction.LengthSquared() < 0.01f)
+                            direction = _random.NextVector2();
+
+                        _throwing.TryThrow(uid, direction.Normalized() * 2.5f, drake.SwoopThrowSpeed, boss, playSound: false, doSpin: false);
+                    }
+
+                    _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-4f));
+                }
             }
-
-            var tile = _map.LocalToTile(gridUid, grid, xform.Coordinates);
-            if (ChebyshevDistance(center, tile) > radius)
-                continue;
-
-            _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
-
-            if (ignite)
-                IgniteEntity(uid, drake, boss);
-
-            if (throwTargets)
-            {
-                var direction = new Vector2(tile.X - center.X, tile.Y - center.Y);
-                if (direction.LengthSquared() < 0.01f)
-                    direction = _random.NextVector2();
-
-                _throwing.TryThrow(uid, direction.Normalized() * 2.5f, drake.SwoopThrowSpeed, boss, playSound: false, doSpin: false);
-            }
-
-            _audio.PlayPvs(drake.HitSound, uid, AudioParams.Default.WithVolume(-4f));
         }
+
+        _tileEntities.Clear();
+        _damagedEntities.Clear();
     }
 
     private void IgniteEntity(EntityUid uid, LavalandAshDrakeComponent drake, EntityUid source)

--- a/Content.Server/DeadSpace/Lavaland/LavalandBossArenaSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandBossArenaSystem.cs
@@ -15,6 +15,7 @@ using Content.Shared.Maps;
 using Content.Shared.Mining.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Parallax.Biomes;
 using Robust.Server.Player;
 using Robust.Shared.Audio.Systems;
@@ -70,6 +71,7 @@ public sealed class LavalandBossArenaSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly TileSystem _tile = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
 
     private List<Entity<MapGridComponent>> _nearbyGrids = new();
     private readonly List<EntityUid> _anchoredToDelete = new();
@@ -853,6 +855,8 @@ public sealed class LavalandBossArenaSystem : EntitySystem
         arena.Comp.BossOutsideArenaSince = null;
         arena.Comp.NextBossLeashCheck = now + BossLeashCheckInterval;
         SetBossAiEnabled(arena.Comp.Boss, false);
+        if (TryComp<MobThresholdsComponent>(arena.Comp.Boss, out var thresholds))
+            _mobThreshold.SetMobStateThreshold(arena.Comp.Boss, FixedPoint2.New(arena.Comp.MaxHealth), MobState.Dead, thresholds);
 
         RaiseLocalEvent(arena.Comp.Boss, new LavalandBossResetEvent(arena.Owner, arena.Comp.BossSpawnTile));
 
@@ -1326,5 +1330,8 @@ public sealed class LavalandBossArenaSystem : EntitySystem
 
         if (TryComp<DamageableComponent>(arena.Comp.Boss, out var damageable))
             _damageable.HealDistributed((arena.Comp.Boss, damageable), FixedPoint2.New(healDelta), origin: arena.Comp.Boss);
+
+        if (TryComp<MobThresholdsComponent>(arena.Comp.Boss, out var thresholds))
+            _mobThreshold.SetMobStateThreshold(arena.Comp.Boss, FixedPoint2.New(newMax), MobState.Dead, thresholds);
     }
 }

--- a/Content.Server/DeadSpace/Lavaland/LavalandBubblegumSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandBubblegumSystem.cs
@@ -35,6 +35,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
@@ -43,6 +44,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     private readonly List<EntityUid> _bloodTargets = new();
     private readonly List<Vector2i> _poolTiles = new();
     private readonly List<Vector2i> _cloneTiles = new();
+    private readonly HashSet<EntityUid> _tileEntities = new();
 
     public override void Initialize()
     {
@@ -77,7 +79,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
 
             PruneTracked(bubblegum);
             ProcessActiveClones(bubblegum, now);
-            ProcessCloneCharges(bubblegum, arena, arena.Grid, grid, now);
+            ProcessCloneCharges(uid, bubblegum, arena, arena.Grid, grid, now);
             ProcessPendingBloodTiles(bubblegum, arena, arena.Grid, grid, now);
             ProcessPendingHandAttacks(uid, bubblegum, arena, arena.Grid, grid, now);
 
@@ -89,7 +91,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
                 continue;
             }
 
-            if (GetHealthFraction(uid) <= 0.25f)
+            if (GetHealthFraction(uid) <= Math.Clamp(bubblegum.CloneCriticalHealthThreshold, 0f, 1f))
                 TrySpawnCriticalClones(uid, bubblegum, arena, arena.Grid, grid, now);
 
             if (ProcessCharge(uid, bubblegum, arena, arena.Grid, grid, now) ||
@@ -435,11 +437,17 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     {
         var bossTile = GetEntityTile(boss, gridUid, grid);
         var hit = false;
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+
+        _tileEntities.Clear();
+        _lookup.GetLocalEntitiesIntersecting(gridUid, tile, _tileEntities, flags: LookupFlags.Dynamic | LookupFlags.Sundries, gridComp: grid);
+
+        foreach (var uid in _tileEntities)
         {
             if (uid == boss ||
                 bubblegum.Slaughterlings.Contains(uid) ||
+                !TryComp(uid, out DamageableComponent? damageable) ||
+                !TryComp(uid, out MobStateComponent? mobState) ||
+                !TryComp(uid, out TransformComponent? xform) ||
                 mobState.CurrentState == MobState.Dead ||
                 xform.GridUid != gridUid ||
                 _map.LocalToTile(gridUid, grid, xform.Coordinates) != tile)
@@ -462,6 +470,8 @@ public sealed class LavalandBubblegumSystem : EntitySystem
             _transform.SetCoordinates(uid, _map.GridTileToLocal(gridUid, grid, destination));
             _audio.PlayPvs(bubblegum.ExitBloodSound, uid, AudioParams.Default.WithVolume(-3f));
         }
+
+        _tileEntities.Clear();
 
         if (hit)
             _audio.PlayPvs(bubblegum.AttackSound, _map.GridTileToLocal(gridUid, grid, tile), AudioParams.Default.WithVolume(-2f));
@@ -824,21 +834,31 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     }
 
     private bool DamageChargeTile(
-        EntityUid boss,
+        EntityUid attacker,
         LavalandBubblegumComponent bubblegum,
         EntityUid gridUid,
         MapGridComponent grid,
         Vector2i tile,
         Vector2i chargeDirection,
-        DamageSpecifier? damageOverride = null)
+        DamageSpecifier? damageOverride = null,
+        EntityUid? additionalIgnored = null,
+        HashSet<EntityUid>? hitEntities = null)
     {
         var hit = false;
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        hitEntities ??= bubblegum.ChargeHitEntities;
+
+        _tileEntities.Clear();
+        _lookup.GetLocalEntitiesIntersecting(gridUid, tile, _tileEntities, flags: LookupFlags.Dynamic | LookupFlags.Sundries, gridComp: grid);
+
+        foreach (var uid in _tileEntities)
         {
-            if (uid == boss ||
+            if (uid == attacker ||
+                uid == additionalIgnored ||
                 bubblegum.Slaughterlings.Contains(uid) ||
-                bubblegum.ChargeHitEntities.Contains(uid) ||
+                hitEntities.Contains(uid) ||
+                !TryComp(uid, out DamageableComponent? damageable) ||
+                !TryComp(uid, out MobStateComponent? mobState) ||
+                !TryComp(uid, out TransformComponent? xform) ||
                 mobState.CurrentState == MobState.Dead ||
                 xform.GridUid != gridUid ||
                 _map.LocalToTile(gridUid, grid, xform.Coordinates) != tile)
@@ -846,16 +866,18 @@ public sealed class LavalandBubblegumSystem : EntitySystem
                 continue;
             }
 
-            _damageable.TryChangeDamage((uid, damageable), damageOverride ?? bubblegum.ChargeDamage, origin: boss);
-            bubblegum.ChargeHitEntities.Add(uid);
+            _damageable.TryChangeDamage((uid, damageable), damageOverride ?? bubblegum.ChargeDamage, origin: attacker);
+            hitEntities.Add(uid);
             hit = true;
 
             var direction = new Vector2(chargeDirection.X, chargeDirection.Y);
             if (direction.LengthSquared() < 0.01f)
                 direction = _random.NextVector2();
 
-            _throwing.TryThrow(uid, direction.Normalized() * 2.5f, bubblegum.ChargeThrowSpeed, boss, playSound: false, doSpin: false);
+            _throwing.TryThrow(uid, direction.Normalized() * 2.5f, bubblegum.ChargeThrowSpeed, attacker, playSound: false, doSpin: false);
         }
+
+        _tileEntities.Clear();
 
         if (hit)
             _audio.PlayPvs(bubblegum.ImpactSound, _map.GridTileToLocal(gridUid, grid, tile), AudioParams.Default.WithVolume(0f));
@@ -905,6 +927,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     }
 
     private void ProcessCloneCharges(
+        EntityUid boss,
         LavalandBubblegumComponent bubblegum,
         LavalandBossArenaComponent arena,
         EntityUid gridUid,
@@ -947,7 +970,7 @@ public sealed class LavalandBubblegumSystem : EntitySystem
             SpawnAnchored(bubblegum.BloodSplatterPrototype, gridUid, grid, nextTile);
             _transform.SetCoordinates(charge.Entity, _map.GridTileToLocal(gridUid, grid, nextTile));
             if (charge.ChargeDamage != null)
-                DamageChargeTile(charge.Entity, bubblegum, gridUid, grid, nextTile, nextTile - currentTile.Value, charge.ChargeDamage);
+                DamageChargeTile(charge.Entity, bubblegum, gridUid, grid, nextTile, nextTile - currentTile.Value, charge.ChargeDamage, boss, charge.HitEntities);
 
             charge.RemainingSteps--;
             charge.NextStep = now + bubblegum.ChargeStepDelay;
@@ -1134,7 +1157,8 @@ public sealed class LavalandBubblegumSystem : EntitySystem
         TimeSpan duration)
     {
         if (string.IsNullOrWhiteSpace(bubblegum.ClonePrototype) ||
-            !_prototype.HasIndex<EntityPrototype>(bubblegum.ClonePrototype))
+            !_prototype.HasIndex<EntityPrototype>(bubblegum.ClonePrototype) ||
+            bubblegum.ActiveClones.Count >= Math.Max(0, bubblegum.MaxActiveClones))
         {
             return null;
         }
@@ -1840,14 +1864,22 @@ public sealed class LavalandBubblegumSystem : EntitySystem
     {
         if (now < bubblegum.NextCriticalCloneSpawn)
             return;
-    
-        bubblegum.NextCriticalCloneSpawn = now + TimeSpan.FromSeconds(1.5);
+
+        var availableClones = Math.Max(0, bubblegum.MaxActiveClones - bubblegum.ActiveClones.Count);
+        if (availableClones <= 0)
+            return;
+
+        var cloneCount = Math.Min(Math.Max(0, bubblegum.CloneCriticalCount), availableClones);
+        if (cloneCount <= 0)
+            return;
+
+        bubblegum.NextCriticalCloneSpawn = now + bubblegum.CriticalCloneCooldown;
     
         var bossTile = GetEntityTile(boss, gridUid, grid);
         if (bossTile == null)
             return;
     
-        PickCloneTiles(bubblegum, arena, bossTile.Value, bubblegum.CloneCriticalCount, _cloneTiles);
+        PickCloneTiles(bubblegum, arena, bossTile.Value, cloneCount, _cloneTiles);
     
         var chargeDuration = bubblegum.ChargeWindup +
                              TimeSpan.FromSeconds(bubblegum.ChargeStepDelay.TotalSeconds * bubblegum.TripleChargeSteps) +

--- a/Content.Server/DeadSpace/Lavaland/LavalandHierophantSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandHierophantSystem.cs
@@ -48,12 +48,15 @@ public sealed class LavalandHierophantSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPlayerManager _players = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private readonly List<EntityUid> _participants = new();
     private readonly HashSet<Vector2i> _detonatingTiles = new();
     private readonly Dictionary<Vector2i, DamageSpecifier> _detonatingDamage = new();
+    private readonly HashSet<EntityUid> _tileEntities = new();
+    private readonly HashSet<EntityUid> _damagedEntities = new();
 
     public override void Initialize()
     {
@@ -766,26 +769,42 @@ public sealed class LavalandHierophantSystem : EntitySystem
         EntityUid gridUid,
         MapGridComponent grid)
     {
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        _damagedEntities.Clear();
+
+        foreach (var tile in _detonatingTiles)
         {
-            if (uid == boss ||
-                mobState.CurrentState == MobState.Dead ||
-                xform.GridUid != gridUid)
-            {
+            if (!_detonatingDamage.TryGetValue(tile, out var damage))
                 continue;
-            }
 
-            var tile = _map.LocalToTile(gridUid, grid, xform.Coordinates);
-            if (!_detonatingTiles.Contains(tile) ||
-                !_detonatingDamage.TryGetValue(tile, out var damage))
+            _tileEntities.Clear();
+            _lookup.GetLocalEntitiesIntersecting(
+                gridUid,
+                tile,
+                _tileEntities,
+                flags: LookupFlags.Dynamic | LookupFlags.Sundries,
+                gridComp: grid);
+
+            foreach (var uid in _tileEntities)
             {
-                continue;
-            }
+                if (uid == boss ||
+                    !_damagedEntities.Add(uid) ||
+                    !TryComp(uid, out DamageableComponent? damageable) ||
+                    !TryComp(uid, out MobStateComponent? mobState) ||
+                    mobState.CurrentState == MobState.Dead ||
+                    !TryComp(uid, out TransformComponent? xform) ||
+                    xform.GridUid != gridUid ||
+                    _map.LocalToTile(gridUid, grid, xform.Coordinates) != tile)
+                {
+                    continue;
+                }
 
-            _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
-            _audio.PlayPvs(hierophant.HitSound, uid, AudioParams.Default.WithVolume(-4f));
+                _damageable.TryChangeDamage((uid, damageable), damage, origin: boss);
+                _audio.PlayPvs(hierophant.HitSound, uid, AudioParams.Default.WithVolume(-4f));
+            }
         }
+
+        _tileEntities.Clear();
+        _damagedEntities.Clear();
     }
 
     private int CollectParticipants(LavalandBossArenaComponent arena)

--- a/Content.Server/DeadSpace/Lavaland/LavalandMiningSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandMiningSystem.cs
@@ -92,16 +92,17 @@ public sealed class LavalandMiningSystem : EntitySystem
         if (HasComp<FultonComponent>(args.Used))
             return;
 
-        if (!TryComp<StackComponent>(args.Used, out _) &&
-            !TryComp<StorageComponent>(args.Used, out _))
+        var usedIsStack = HasComp<StackComponent>(args.Used);
+        var usedIsStorage = HasComp<StorageComponent>(args.Used);
+
+        if (!usedIsStack && !usedIsStorage)
         {
             return;
         }
 
-        args.Handled = true;
-
         if (!this.IsPowered(ent.Owner, EntityManager))
         {
+            args.Handled = true;
             _popup.PopupEntity(Loc.GetString("lavaland-ore-redeemer-unpowered"), ent.Owner, args.User);
             return;
         }
@@ -109,6 +110,10 @@ public sealed class LavalandMiningSystem : EntitySystem
         var hasCard = TryGetMiningCard(args.User, ent.Comp.MiningAccess, out var cardUid, out var points);
 
         var result = Redeem(args.User, args.Used, ent.Owner, ent.Comp, hasCard);
+        if (result.Units <= 0 && !usedIsStorage)
+            return;
+
+        args.Handled = true;
         ApplyRedeemResult(ent.Owner, args.User, result, hasCard, cardUid, points);
     }
 

--- a/Content.Server/DeadSpace/Lavaland/LavalandWeatherSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandWeatherSystem.cs
@@ -27,12 +27,14 @@ public sealed class LavalandWeatherSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedWeatherSystem _weather = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
 
     private EntityQuery<LavalandWeatherImmuneComponent> _immuneQuery;
     private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<TransformComponent> _xformQuery;
+    private readonly HashSet<EntityUid> _weatherEntities = new();
 
     public override void Initialize()
     {
@@ -184,10 +186,24 @@ public sealed class LavalandWeatherSystem : EntitySystem
         if (planet.AshStormDamage.Empty)
             return;
 
-        var query = EntityQueryEnumerator<DamageableComponent, MobStateComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var damageable, out var mobState, out var xform))
+        var damage = new DamageSpecifier(planet.AshStormDamage);
+        var mapId = Transform(mapUid).MapID;
+        var halfSize = GetWeatherLookupHalfSize(planet);
+        var bounds = new Box2(-halfSize, -halfSize, halfSize, halfSize);
+
+        _weatherEntities.Clear();
+        _lookup.GetEntitiesIntersecting(
+            mapId,
+            bounds,
+            _weatherEntities,
+            LookupFlags.Dynamic | LookupFlags.Sundries);
+
+        foreach (var uid in _weatherEntities)
         {
-            if (xform.MapUid != mapUid ||
+            if (!TryComp(uid, out DamageableComponent? damageable) ||
+                !TryComp(uid, out MobStateComponent? mobState) ||
+                !TryComp(uid, out TransformComponent? xform) ||
+                xform.MapUid != mapUid ||
                 xform.GridUid is not { } gridUid ||
                 !_gridQuery.TryGetComponent(gridUid, out var grid) ||
                 !_map.TryGetTileRef(gridUid, grid, xform.Coordinates, out var tile) ||
@@ -203,9 +219,10 @@ public sealed class LavalandWeatherSystem : EntitySystem
                 continue;
             }
 
-            var damage = new DamageSpecifier(planet.AshStormDamage);
             _damageable.TryChangeDamage((uid, damageable), damage, interruptsDoAfters: false, origin: mapUid);
         }
+
+        _weatherEntities.Clear();
     }
 
     private bool IsWeatherImmune(EntityUid uid, TransformComponent xform)
@@ -259,6 +276,15 @@ public sealed class LavalandWeatherSystem : EntitySystem
     {
         var interval = ClampDuration(planet.AshStormDamageInterval);
         return interval == TimeSpan.Zero ? TimeSpan.FromSeconds(1) : interval;
+    }
+
+    private static float GetWeatherLookupHalfSize(LavalandPlanetPrototype planet)
+    {
+        const float MinExtraMargin = 64f;
+        var halfSize = Math.Max(1, planet.MapHalfSize);
+        var extraMargin = Math.Max(MinExtraMargin, planet.FtlFallbackMaxOffset + MinExtraMargin);
+
+        return halfSize + extraMargin;
     }
 
     private static TimeSpan ClampDuration(TimeSpan duration)

--- a/Content.Server/DeadSpace/Taipan/TaipanStationSystem.cs
+++ b/Content.Server/DeadSpace/Taipan/TaipanStationSystem.cs
@@ -3,9 +3,13 @@
 using System.Linq;
 using Content.Server.DeadSpace.Taipan.Components;
 using Content.Server.GameTicking;
+using Content.Server.Shuttles.Components;
+using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components;
 using Content.Shared.DeadSpace.CCCCVars;
 using Content.Shared.GameTicking;
+using Content.Shared.Tag;
+using Content.Shared.Whitelist;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.EntitySerialization;
@@ -17,10 +21,14 @@ namespace Content.Server.DeadSpace.Taipan;
 
 public sealed class TaipanStationSystem : EntitySystem
 {
+    private static readonly ProtoId<TagPrototype> TaipanTag = "Taipan";
+
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly ShuttleSystem _shuttle = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     private EntityUid _stationGrid = EntityUid.Invalid;
     private MapId _mapId = MapId.Nullspace;
@@ -84,6 +92,7 @@ public sealed class TaipanStationSystem : EntitySystem
 
         if (_stationGrid.IsValid())
         {
+            SetupTaipanFtl();
             return;
         }
 
@@ -91,5 +100,28 @@ public sealed class TaipanStationSystem : EntitySystem
 
         var opts = DeserializationOptions.Default with { InitializeMaps = true };
         _stationGrid = _gameTicker.LoadGameMap(_prototypeManager.Index(source.Comp.Station), out _mapId, opts).FirstOrNull(HasComp<BecomesStationComponent>)!.Value;
+        SetupTaipanFtl();
+    }
+
+    private void SetupTaipanFtl()
+    {
+        if (_mapId == MapId.Nullspace)
+            return;
+
+        if (!_shuttle.TryAddFTLDestination(_mapId, true, false, false, out var destination))
+            return;
+
+        var mapUid = _map.GetMapOrInvalid(_mapId);
+        _shuttle.SetFTLWhitelist((mapUid, destination), new EntityWhitelist
+        {
+            Tags = new List<ProtoId<TagPrototype>> { TaipanTag },
+        });
+
+        var query = EntityQueryEnumerator<ShuttleComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var xform))
+        {
+            if (xform.MapID == _mapId)
+                _tag.AddTag(uid, TaipanTag);
+        }
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -65,11 +65,14 @@ public sealed partial class GunSystem : SharedGunSystem
             }
         }
 
-        var fromMap = TransformSystem.ToMapCoordinates(fromCoordinates);
-        var toMap = TransformSystem.ToMapCoordinates(toCoordinates).Position;
-        var mapDirection = toMap - fromMap.Position;
+        if (!TryGetShootMapDirection(fromCoordinates, toCoordinates, out var fromMap, out var mapDirection))
+        {
+            userImpulse = false;
+            return;
+        }
+
         var mapAngle = mapDirection.ToAngle();
-        var angle = GetRecoilAngle(Timing.CurTime, gun, mapDirection.ToAngle());
+        var angle = GetRecoilAngle(Timing.CurTime, gun, mapAngle);
 
         // If applicable, this ensures the projectile is parented to grid on spawn, instead of the map.
         var fromEnt = MapManager.TryFindGridAt(fromMap, out var gridUid, out _)
@@ -77,7 +80,7 @@ public sealed partial class GunSystem : SharedGunSystem
             : new EntityCoordinates(_map.GetMapOrInvalid(fromMap.MapId), fromMap.Position);
 
         // Update shot based on the recoil
-        toMap = fromMap.Position + angle.ToVec() * mapDirection.Length();
+        var toMap = fromMap.Position + angle.ToVec() * mapDirection.Length();
         mapDirection = toMap - fromMap.Position;
         var gunVelocity = Physics.GetMapLinearVelocity(fromEnt);
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -71,7 +71,9 @@ public abstract partial class SharedPuddleSystem
             if (puddleSolution.Volume == FixedPoint2.Zero)
             {
                 // Spawn a *sparkle*
-                SpawnAttachedTo(evaporation.EvaporationEffect, Transform(uid).Coordinates);
+                if (_net.IsServer) // TODO: Change this once we have entity spawn prediction V2
+                    SpawnAttachedTo(evaporation.EvaporationEffect, Transform(uid).Coordinates);
+
                 PredictedQueueDel(uid);
             }
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -41,6 +42,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
     [Dependency] private readonly SpeedModifierContactsSystem _speedModContacts = default!;
     [Dependency] private readonly StepTriggerSystem _stepTrigger = default!;
     [Dependency] private readonly TileFrictionController _tile = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     private ProtoId<ReagentPrototype>[] _standoutReagents = [];
 
@@ -318,8 +320,16 @@ public abstract partial class SharedPuddleSystem : EntitySystem
         Dirty(entity, slipComp);
     }
 
-    private void UpdateSlow(EntityUid uid, Solution solution)
+    private void UpdateSlow(Entity<PuddleComponent> entity, Solution solution)
     {
+        var uid = entity.Owner;
+
+        if (!entity.Comp.ViscosityAffectsMovement)
+        {
+            RemComp<SpeedModifierContactsComponent>(uid);
+            return;
+        }
+
         var maxViscosity = 0f;
         foreach (var (reagent, _) in solution.Contents)
         {
@@ -332,7 +342,6 @@ public abstract partial class SharedPuddleSystem : EntitySystem
             var comp = EnsureComp<SpeedModifierContactsComponent>(uid);
             var speed = 1 - maxViscosity;
             _speedModContacts.ChangeSpeedModifiers(uid, speed, comp);
-            Dirty(uid, comp); //DS14
         }
         else
         {

--- a/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
@@ -61,6 +61,10 @@ public sealed class SpeedModifierContactsSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
+        if (MathHelper.CloseTo(component.WalkSpeedModifier, walkSpeed) &&
+            MathHelper.CloseTo(component.SprintSpeedModifier, sprintSpeed))
+            return;
+
         component.WalkSpeedModifier = walkSpeed;
         component.SprintSpeedModifier = sprintSpeed;
         Dirty(uid, component);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -263,6 +263,15 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (toCoordinates == null)
             return false;
 
+        var fromCoordinates = Transform(user).Coordinates;
+
+        if (!TryGetShootMapDirection(fromCoordinates, toCoordinates.Value, out _, out _))
+        {
+            gun.Comp.BurstActivated = false;
+            gun.Comp.BurstShotsCount = 0;
+            return false;
+        }
+
         var curTime = Timing.CurTime;
 
         // check if anything wants to prevent shooting
@@ -345,7 +354,6 @@ public abstract partial class SharedGunSystem : EntitySystem
             return false;
         }
 
-        var fromCoordinates = Transform(user).Coordinates;
         // Remove ammo
         var ev = new TakeAmmoEvent(shots, [], fromCoordinates, user);
 
@@ -533,6 +541,27 @@ public abstract partial class SharedGunSystem : EntitySystem
         RemCompDeferred<AmmoComponent>(uid);
     }
 
+    protected bool TryGetShootMapDirection(
+        EntityCoordinates fromCoordinates,
+        EntityCoordinates toCoordinates,
+        out MapCoordinates fromMap,
+        out Vector2 direction)
+    {
+        fromMap = TransformSystem.ToMapCoordinates(fromCoordinates, logError: false);
+        var toMap = TransformSystem.ToMapCoordinates(toCoordinates, logError: false);
+        direction = Vector2.Zero;
+
+        if (fromMap.MapId == MapId.Nullspace ||
+            toMap.MapId == MapId.Nullspace ||
+            fromMap.MapId != toMap.MapId)
+        {
+            return false;
+        }
+
+        direction = toMap.Position - fromMap.Position;
+        return direction.LengthSquared() > 0.0001f;
+    }
+
     protected void MuzzleFlash(EntityUid gun, AmmoComponent component, Angle worldAngle, EntityUid? user = null)
     {
         var attemptEv = new GunMuzzleFlashAttemptEvent();
@@ -551,9 +580,10 @@ public abstract partial class SharedGunSystem : EntitySystem
 
     public void CauseImpulse(EntityCoordinates fromCoordinates, EntityCoordinates toCoordinates, Entity<PhysicsComponent> user)
     {
-        var fromMap = TransformSystem.ToMapCoordinates(fromCoordinates).Position;
-        var toMap = TransformSystem.ToMapCoordinates(toCoordinates).Position;
-        var shotDirection = (toMap - fromMap).Normalized();
+        if (!TryGetShootMapDirection(fromCoordinates, toCoordinates, out _, out var direction))
+            return;
+
+        var shotDirection = direction.Normalized();
 
         const float impulseStrength = 25.0f;
         var impulseVector = shotDirection * impulseStrength;

--- a/Resources/ConfigPresets/Build/debug.toml
+++ b/Resources/ConfigPresets/Build/debug.toml
@@ -1,1 +1,2 @@
-﻿
+[lavaland]
+auto_generate = false

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -56,3 +56,6 @@ rules_file = "DeadSpaceDefaultRuleset"
 
 [taipan]
 enabled = false
+
+[lavaland]
+auto_generate = false

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -177,7 +177,7 @@
       slipFixture:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.4,-0.4,0.4,0.4"
+          bounds: "-0.5,-0.5,0.5,0.5"
         mask:
         - ItemMask
         layer:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -340,6 +340,8 @@
     - HivelordRemains
     - Meat
     - Raw
+    - FelinidFood # DS14
+    - ReptilianFood
 
 - type: entity
   id: FoodHivelordRemainsInert

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -997,7 +997,7 @@
     solution:
       reagents:
       - ReagentId: SpaceCleaner
-        Quantity: 30
+        Quantity: 60
   - type: EmitSoundOnTrigger
     sound: /Audio/Items/smoke_grenade_smoke.ogg
     positional: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/canister_grenades.yml
@@ -40,7 +40,7 @@
     solution:
       reagents:
       - ReagentId: SpaceCleaner
-        Quantity: 30
+        Quantity: 60
   - type: Tag # DS14
     tags:
     - CleanerGrenade

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -31,6 +31,10 @@
     cleanCost: 0.13
   - !type:CleanDecalsReaction
     cleanCost: 0.13
+  - !type:ReplaceTileReaction
+    cost: 0.13
+    replacements:
+      FloorSteelDirty: FloorSteel
 
 - type: reagent
   id: SpaceCleaner
@@ -43,8 +47,12 @@
   boilingPoint: 147.0 # Made this up, loosely based on bleach
   meltingPoint: -11.0
   tileReactions:
-    - !type:CleanTileReaction {}
+    - !type:CleanTileReaction
+      cleanCost: 0.01
     - !type:CleanDecalsReaction {}
+    - !type:ReplaceTileReaction
+      replacements:
+        FloorSteelDirty: FloorSteel
 
 - type: reagent
   id: SoapReagent

--- a/Resources/Prototypes/_DeadSpace/Lavaland/rewards.yml
+++ b/Resources/Prototypes/_DeadSpace/Lavaland/rewards.yml
@@ -77,6 +77,10 @@
     state: legion_soul
   - type: Item
     size: Small
+  - type: Tag
+    tags:
+    - FelinidFood
+    - ReptilianFood
   - type: Perishable
     rotAfter: 180
     molsPerSecondPerUnitMass: 0


### PR DESCRIPTION
:cl:
  - Исправлено: фелиниды и унатхи могут есть души легиона и останки роев.
  - Исправлено: чистящие гранаты лучше очищают грязь, декали, лужи.
  - Исправлено: порог смерти лаваленд-боссов обновляется при скейле здоровья.
  - Исправлено: неверное сообщение при ручной вставке неподдерживаемой руды.
  - Исправлено: лаги на лужах. (возможно! нужно тестить на сервере)
  - Исправлено: пули больше не должны улетать в неверную сторону из-за рассинхрона поворота персонажа и координат прицеливания.
  - Исправлено: тайпановцы могут вернутся с лаваленда обратно.
