### PR TITLE
Фикс очков за руду при частичной загрузке ящика

### DIFF
--- a/Content.IntegrationTests/Tests/DeadSpace/Lavaland/LavalandOreRedeemerTest.cs
+++ b/Content.IntegrationTests/Tests/DeadSpace/Lavaland/LavalandOreRedeemerTest.cs
@@ -1,0 +1,291 @@
+using Content.Server.DeadSpace.Lavaland.Components;
+using Content.Server.Stack;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Stacks;
+using Content.Shared.Storage;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests.DeadSpace.Lavaland;
+
+[TestFixture]
+public sealed class LavalandOreRedeemerTest
+{
+    private const string SteelOre = "SteelOre";
+    private const string GoldOre = "GoldOre";
+
+    [Test]
+    public async Task FullStorageInsertRedeemsInsertedOre()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            Dirty = true,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var storage = server.System<StorageSystem>();
+        var stack = server.System<StackSystem>();
+
+        EntityUid incomingOre = default;
+
+        await server.WaitPost(() =>
+        {
+            var oreBox = entMan.SpawnEntity("OreBox", MapCoordinates.Nullspace);
+            var oreBag = entMan.SpawnEntity("OreBag", MapCoordinates.Nullspace);
+            incomingOre = SpawnOre(entMan, stack, SteelOre, 30);
+
+            Assert.That(storage.Insert(oreBag, incomingOre, out _, playSound: false), Is.True);
+
+            var ev = RedeemBagIntoBox(entMan, oreBag, oreBox);
+
+            Assert.That(ev.Handled, Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<StackComponent>(incomingOre).Count, Is.EqualTo(30));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(incomingOre).ProcessedUnits, Is.EqualTo(30));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(incomingOre).CreditedUnits, Is.EqualTo(0));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PartialStorageMergeDoesNotRedeemLeftoverOre()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            Dirty = true,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var storage = server.System<StorageSystem>();
+        var stack = server.System<StackSystem>();
+
+        EntityUid existingOre = default;
+        EntityUid incomingOre = default;
+
+        await server.WaitPost(() =>
+        {
+            var oreBox = entMan.SpawnEntity("OreBox", MapCoordinates.Nullspace);
+            var oreBag = entMan.SpawnEntity("OreBag", MapCoordinates.Nullspace);
+            existingOre = SpawnOre(entMan, stack, SteelOre, 20);
+            incomingOre = SpawnOre(entMan, stack, SteelOre, 30);
+
+            Assert.That(storage.Insert(oreBox, existingOre, out _, playSound: false), Is.True);
+            Assert.That(storage.Insert(oreBag, incomingOre, out _, playSound: false), Is.True);
+
+            BlockNewStorageItems(entMan, oreBox);
+
+            var ev = RedeemBagIntoBox(entMan, oreBag, oreBox);
+
+            Assert.That(ev.Handled, Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<StackComponent>(existingOre).Count, Is.EqualTo(30));
+                Assert.That(entMan.GetComponent<StackComponent>(incomingOre).Count, Is.EqualTo(20));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(existingOre).ProcessedUnits, Is.EqualTo(10));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(existingOre).CreditedUnits, Is.EqualTo(0));
+                AssertUnredeemed(entMan, incomingOre);
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task FullStorageDoesNotRedeemUninsertedOre()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            Dirty = true,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var storage = server.System<StorageSystem>();
+        var stack = server.System<StackSystem>();
+
+        EntityUid existingOre = default;
+        EntityUid incomingOre = default;
+
+        await server.WaitPost(() =>
+        {
+            var oreBox = entMan.SpawnEntity("OreBox", MapCoordinates.Nullspace);
+            var oreBag = entMan.SpawnEntity("OreBag", MapCoordinates.Nullspace);
+            existingOre = SpawnOre(entMan, stack, SteelOre, 30);
+            incomingOre = SpawnOre(entMan, stack, SteelOre, 30);
+
+            Assert.That(storage.Insert(oreBox, existingOre, out _, playSound: false), Is.True);
+            Assert.That(storage.Insert(oreBag, incomingOre, out _, playSound: false), Is.True);
+
+            BlockNewStorageItems(entMan, oreBox);
+
+            var ev = RedeemBagIntoBox(entMan, oreBag, oreBox);
+
+            Assert.That(ev.Handled, Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<StackComponent>(existingOre).Count, Is.EqualTo(30));
+                Assert.That(entMan.GetComponent<StackComponent>(incomingOre).Count, Is.EqualTo(30));
+                AssertUnredeemed(entMan, existingOre);
+                AssertUnredeemed(entMan, incomingOre);
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DifferentOreWithoutSlotDoesNotRedeemUninsertedOre()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            Dirty = true,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var storage = server.System<StorageSystem>();
+        var stack = server.System<StackSystem>();
+
+        EntityUid existingOre = default;
+        EntityUid incomingOre = default;
+
+        await server.WaitPost(() =>
+        {
+            var oreBox = entMan.SpawnEntity("OreBox", MapCoordinates.Nullspace);
+            var oreBag = entMan.SpawnEntity("OreBag", MapCoordinates.Nullspace);
+            existingOre = SpawnOre(entMan, stack, SteelOre, 20);
+            incomingOre = SpawnOre(entMan, stack, GoldOre, 30);
+
+            Assert.That(storage.Insert(oreBox, existingOre, out _, playSound: false), Is.True);
+            Assert.That(storage.Insert(oreBag, incomingOre, out _, playSound: false), Is.True);
+
+            BlockNewStorageItems(entMan, oreBox);
+
+            var ev = RedeemBagIntoBox(entMan, oreBag, oreBox);
+
+            Assert.That(ev.Handled, Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<StackComponent>(existingOre).Count, Is.EqualTo(20));
+                Assert.That(entMan.GetComponent<StackComponent>(incomingOre).Count, Is.EqualTo(30));
+                AssertUnredeemed(entMan, existingOre);
+                AssertUnredeemed(entMan, incomingOre);
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task PartialStorageMergeKeepsRedeemedStateOnInsertedUnitsOnly()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = false,
+            Dirty = true,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var storage = server.System<StorageSystem>();
+        var stack = server.System<StackSystem>();
+
+        EntityUid existingOre = default;
+        EntityUid incomingOre = default;
+
+        await server.WaitPost(() =>
+        {
+            var oreBox = entMan.SpawnEntity("OreBox", MapCoordinates.Nullspace);
+            var oreBag = entMan.SpawnEntity("OreBag", MapCoordinates.Nullspace);
+            existingOre = SpawnOre(entMan, stack, SteelOre, 15);
+            incomingOre = SpawnOre(entMan, stack, SteelOre, 30);
+
+            var redeemed = entMan.EnsureComponent<LavalandRedeemedOreComponent>(incomingOre);
+            redeemed.ProcessedUnits = 10;
+            redeemed.CreditedUnits = 10;
+
+            Assert.That(storage.Insert(oreBox, existingOre, out _, playSound: false), Is.True);
+            Assert.That(storage.Insert(oreBag, incomingOre, out _, playSound: false), Is.True);
+
+            BlockNewStorageItems(entMan, oreBox);
+
+            var ev = RedeemBagIntoBox(entMan, oreBag, oreBox);
+
+            Assert.That(ev.Handled, Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.GetComponent<StackComponent>(existingOre).Count, Is.EqualTo(30));
+                Assert.That(entMan.GetComponent<StackComponent>(incomingOre).Count, Is.EqualTo(15));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(existingOre).ProcessedUnits, Is.EqualTo(15));
+                Assert.That(entMan.GetComponent<LavalandRedeemedOreComponent>(existingOre).CreditedUnits, Is.EqualTo(10));
+                AssertUnredeemed(entMan, incomingOre);
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static EntityUid SpawnOre(IEntityManager entMan, StackSystem stack, string prototype, int count)
+    {
+        var ore = entMan.SpawnEntity(prototype, MapCoordinates.Nullspace);
+        stack.SetCount((ore, entMan.GetComponent<StackComponent>(ore)), count);
+        return ore;
+    }
+
+    private static void AssertUnredeemed(IEntityManager entMan, EntityUid ore)
+    {
+        if (!entMan.TryGetComponent<LavalandRedeemedOreComponent>(ore, out var redeemed))
+            return;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(redeemed.ProcessedUnits, Is.EqualTo(0));
+            Assert.That(redeemed.CreditedUnits, Is.EqualTo(0));
+        });
+    }
+
+    private static void BlockNewStorageItems(IEntityManager entMan, EntityUid storageUid)
+    {
+        var storage = entMan.GetComponent<StorageComponent>(storageUid);
+        storage.Grid.Clear();
+        storage.OccupiedGrid.Clear();
+    }
+
+    private static InteractUsingEvent RedeemBagIntoBox(IEntityManager entMan, EntityUid oreBag, EntityUid oreBox)
+    {
+        var coordinates = entMan.GetComponent<TransformComponent>(oreBox).Coordinates;
+        var ev = new InteractUsingEvent(oreBag, oreBag, oreBox, coordinates);
+        entMan.EventBus.RaiseLocalEvent(oreBox, ev);
+        return ev;
+    }
+}

--- a/Content.Server/DeadSpace/Lavaland/LavalandMiningSystem.cs
+++ b/Content.Server/DeadSpace/Lavaland/LavalandMiningSystem.cs
@@ -398,7 +398,7 @@ public sealed class LavalandMiningSystem : EntitySystem
     {
         if (HasComp<FultonComponent>(uid))
             return;
-    
+
         if (!TryComp<StackComponent>(uid, out var stack) ||
             !TryComp<PhysicalCompositionComponent>(uid, out var composition) ||
             stack.Unlimited ||
@@ -417,6 +417,9 @@ public sealed class LavalandMiningSystem : EntitySystem
             ? Math.Clamp(redeemedOre.CreditedUnits, 0, processedUnits)
             : 0;
         var freshUnits = count - processedUnits;
+        var redeemedUnits = count;
+        var redeemedFreshUnits = freshUnits;
+        var redeemedCreditedUnits = creditedUnits;
         if (HasComp<LatheComponent>(receiver))
         {
             if (!_materialStorage.TryInsertMaterialEntity(user, uid, receiver, showPopup: false))
@@ -425,23 +428,127 @@ public sealed class LavalandMiningSystem : EntitySystem
             AddProcessedMaterials(component, composition, count);
             AddCreditedMaterials(component, composition, creditedUnits + (awardFreshOre ? freshUnits : 0));
         }
-        else if (HasComp<StorageComponent>(receiver))
+        else if (TryComp<StorageComponent>(receiver, out var storage))
         {
-            if (!_storageSystem.Insert(receiver, uid, out _, user: user, playSound: false))
+            var beforeCounts = GetStorageStackCounts((receiver, storage), stack.StackTypeId);
+
+            if (!_storageSystem.Insert(receiver, uid, out _, user: user, storageComp: storage, playSound: false))
                 return;
 
-            AddProcessedMaterials(component, composition, count);
-            AddCreditedMaterials(component, composition, creditedUnits + (awardFreshOre ? freshUnits : 0));
-            AddRedeemedUnits(uid, freshUnits, awardFreshOre ? freshUnits : 0, count);
+            redeemedUnits = GetInsertedStackUnits((receiver, storage), stack.StackTypeId, beforeCounts);
+            if (redeemedUnits <= 0)
+                return;
+
+            var insertedProcessedUnits = Math.Min(processedUnits, redeemedUnits);
+            redeemedCreditedUnits = Math.Min(creditedUnits, insertedProcessedUnits);
+            redeemedFreshUnits = redeemedUnits - insertedProcessedUnits;
+
+            AddProcessedMaterials(component, composition, redeemedUnits);
+            AddCreditedMaterials(component, composition, redeemedCreditedUnits + (awardFreshOre ? redeemedFreshUnits : 0));
+            AddRedeemedFreshUnitsToInsertedStacks(
+                (receiver, storage),
+                stack.StackTypeId,
+                beforeCounts,
+                insertedProcessedUnits,
+                redeemedFreshUnits,
+                awardFreshOre ? redeemedFreshUnits : 0);
         }
         else
         {
             QueueDel(uid);
         }
 
-        result.Units += count;
-        result.Points += freshUnits * pointsPerUnit;
-        result.Debt += creditedUnits * pointsPerUnit;
+        result.Units += redeemedUnits;
+        result.Points += redeemedFreshUnits * pointsPerUnit;
+        result.Debt += redeemedCreditedUnits * pointsPerUnit;
+    }
+
+    private Dictionary<EntityUid, int> GetStorageStackCounts(
+        Entity<StorageComponent> storage,
+        ProtoId<StackPrototype> stackType)
+    {
+        var counts = new Dictionary<EntityUid, int>();
+
+        foreach (var contained in storage.Comp.Container.ContainedEntities)
+        {
+            if (!TryComp<StackComponent>(contained, out var containedStack) ||
+                containedStack.StackTypeId != stackType)
+            {
+                continue;
+            }
+
+            counts[contained] = containedStack.Count;
+        }
+
+        return counts;
+    }
+
+    private int GetInsertedStackUnits(
+        Entity<StorageComponent> storage,
+        ProtoId<StackPrototype> stackType,
+        IReadOnlyDictionary<EntityUid, int> beforeCounts)
+    {
+        var inserted = 0;
+
+        foreach (var contained in storage.Comp.Container.ContainedEntities)
+        {
+            if (!TryComp<StackComponent>(contained, out var containedStack) ||
+                containedStack.StackTypeId != stackType)
+            {
+                continue;
+            }
+
+            inserted += Math.Max(0, containedStack.Count - beforeCounts.GetValueOrDefault(contained));
+        }
+
+        return inserted;
+    }
+
+    private void AddRedeemedFreshUnitsToInsertedStacks(
+        Entity<StorageComponent> storage,
+        ProtoId<StackPrototype> stackType,
+        IReadOnlyDictionary<EntityUid, int> beforeCounts,
+        int insertedProcessedUnits,
+        int freshUnits,
+        int creditedFreshUnits)
+    {
+        var processedToSkip = insertedProcessedUnits;
+        var freshRemaining = freshUnits;
+        var creditedRemaining = creditedFreshUnits;
+
+        foreach (var contained in storage.Comp.Container.ContainedEntities)
+        {
+            if (freshRemaining <= 0)
+                break;
+
+            if (!TryComp<StackComponent>(contained, out var containedStack) ||
+                containedStack.StackTypeId != stackType)
+            {
+                continue;
+            }
+
+            var inserted = containedStack.Count - beforeCounts.GetValueOrDefault(contained);
+            if (inserted <= 0)
+                continue;
+
+            if (processedToSkip > 0)
+            {
+                var skipped = Math.Min(processedToSkip, inserted);
+                processedToSkip -= skipped;
+                inserted -= skipped;
+            }
+
+            if (inserted <= 0)
+                continue;
+
+            var processed = Math.Min(freshRemaining, inserted);
+            var credited = Math.Min(creditedRemaining, processed);
+
+            AddRedeemedUnits(contained, processed, credited, containedStack.Count);
+
+            freshRemaining -= processed;
+            creditedRemaining -= credited;
+        }
     }
 
     private static void AddProcessedMaterials(


### PR DESCRIPTION
Исправляет начисление очков у лавалендского ящика руды при частичном переносе стака из сумки.

Теперь обработанными помечаются только те единицы руды, которые реально попали в ящик или смерджились в стак внутри него. Остаток в сумке остается обычной рудой.

## Критические изменения
Нет.

**Список изменений**
:cl:
- Исправлено: Руда, не поместившаяся в ящик при выгрузке из сумки, больше не считается переработанной.