### PR TITLE
Fix dropping items into walls

### DIFF
--- a/Content.IntegrationTests/Tests/Hands/HandTests.cs
+++ b/Content.IntegrationTests/Tests/Hands/HandTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Linq;
 using Content.Server.Storage.EntitySystems;
 using Content.Shared.Hands.Components;
@@ -6,6 +7,7 @@ using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.IntegrationTests.Tests.Hands;
 
@@ -132,6 +134,67 @@ public sealed class HandTests
         var itemXform = entMan.GetComponent<TransformComponent>(item);
         Assert.That(sys.GetActiveItem((player, hands)), Is.Not.EqualTo(item));
         Assert.That(containerSystem.IsInSameOrNoContainer((player, xform), (item, itemXform)));
+
+        await server.WaitPost(() => mapSystem.DeleteMap(map.MapId));
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TestDropTowardsWallKeepsItemOutsideWall()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            DummyTicker = false
+        });
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var playerMan = server.ResolveDependency<IPlayerManager>();
+        var mapSystem = server.System<SharedMapSystem>();
+        var handsSystem = entMan.System<SharedHandsSystem>();
+        var transformSystem = entMan.System<TransformSystem>();
+        var physicsSystem = entMan.System<SharedPhysicsSystem>();
+
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        EntityUid item = default;
+        EntityUid wall = default;
+        EntityUid player = default;
+        HandsComponent hands = default!;
+
+        await server.WaitPost(() =>
+        {
+            player = playerMan.Sessions.First().AttachedEntity!.Value;
+            transformSystem.SetCoordinates(player, map.GridCoords);
+
+            var wallCoords = map.GridCoords.Offset(new Vector2(1f, 0f));
+            wall = entMan.SpawnEntity("WallSolid", wallCoords);
+
+            item = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            hands = entMan.GetComponent<HandsComponent>(player);
+            Assert.That(handsSystem.TryPickup(player, item, hands.ActiveHandId!), Is.True);
+        });
+
+        await pair.RunTicksSync(5);
+        Assert.That(handsSystem.GetActiveItem((player, hands)), Is.EqualTo(item));
+
+        await server.WaitPost(() =>
+        {
+            var wallCoords = map.GridCoords.Offset(new Vector2(1f, 0f));
+            Assert.That(handsSystem.TryDrop(player, item, wallCoords), Is.True);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var itemBounds = physicsSystem.GetWorldAABB(item);
+            var wallBounds = physicsSystem.GetWorldAABB(wall);
+
+            Assert.That(itemBounds.Intersects(wallBounds), Is.False);
+        });
 
         await server.WaitPost(() => mapSystem.DeleteMap(map.MapId));
         await pair.CleanReturnAsync();

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Drop.cs
@@ -7,6 +7,9 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Tag;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -15,8 +18,10 @@ namespace Content.Shared.Hands.EntitySystems;
 public abstract partial class SharedHandsSystem
 {
     [Dependency] private readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     private static readonly ProtoId<TagPrototype> BypassDropChecksTag = "BypassDropChecks";
+    private const float DropCollisionBuffer = PhysicsConstants.PolygonRadius * 4f;
 
     private void InitializeDrop()
     {
@@ -211,8 +216,32 @@ public abstract partial class SharedHandsSystem
         }
 
         if (dropLength < requestedDropDistance)
-            return origin.Position + dropVector.Normalized() * dropLength;
+        {
+            var direction = dropVector.Normalized();
+            var clearance = GetDropForwardClearance(held, origin.Position, direction);
+            return origin.Position + direction * MathF.Max(0f, dropLength - clearance);
+        }
+
         return target.Position;
+    }
+
+    private float GetDropForwardClearance(EntityUid held, Vector2 origin, Vector2 direction)
+    {
+        if (!TryComp<FixturesComponent>(held, out var fixtures) ||
+            !TryComp<PhysicsComponent>(held, out var physics))
+        {
+            return DropCollisionBuffer;
+        }
+
+        var bounds = _physics.GetHardAABB(held, fixtures, physics);
+        var forwardClearance = 0f;
+
+        forwardClearance = MathF.Max(forwardClearance, Vector2.Dot(bounds.BottomLeft - origin, direction));
+        forwardClearance = MathF.Max(forwardClearance, Vector2.Dot(bounds.BottomRight - origin, direction));
+        forwardClearance = MathF.Max(forwardClearance, Vector2.Dot(bounds.TopLeft - origin, direction));
+        forwardClearance = MathF.Max(forwardClearance, Vector2.Dot(bounds.TopRight - origin, direction));
+
+        return forwardClearance + DropCollisionBuffer;
     }
 
     /// <summary>


### PR DESCRIPTION
Исправляет дроп предметов внутрь стен через Q, когда игрок стоит вплотную к препятствию.

Теперь при расчете позиции дропа учитывается физический размер предмета: если луч дропа упирается в стену или другое препятствие, предмет ставится чуть раньше, чтобы его коллизия не залезала внутрь стены.

## Критические изменения
Нет.

**Список изменений**
:cl:
- Исправлено: Предметы больше нельзя класть внутрь стен при дропе на Q вплотную к препятствию.