### PR TITLE
zomboid

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -50,6 +50,7 @@ using Content.Shared.NPC.Components; // DS14
 using System.Linq; // DS14
 using Content.Shared.Cuffs.Components; // DS14
 using Content.Shared.Temperature.Components;
+using Content.Shared.Damage.Components; // DS14
 
 namespace Content.Server.Zombies;
 
@@ -156,6 +157,7 @@ public sealed partial class ZombieSystem
         RemComp<LegsParalyzedComponent>(target);
         RemComp<ComplexInteractionComponent>(target);
         RemComp<SentienceTargetComponent>(target);
+        EnsureComp<IgnoreSlowOnDamageComponent>(target); // DS14
 
         // DS14-start
         if (HasComp<VirusComponent>(target))
@@ -280,7 +282,7 @@ public sealed partial class ZombieSystem
         //Heals the zombie from all the damage it took while human
         _damageable.ClearAllDamage(target);
         _mobState.ChangeMobState(target, MobState.Alive);
-        
+
         // DS14-start
         if (TryComp<NpcFactionMemberComponent>(target, out var factionComp))
         {

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -38,8 +38,8 @@ public sealed partial class ZombieComponent : Component
         DamageDict = new ()
         {
             {"Slash", 0.5},
-            {"Piercing", 0.3},
-            {"Blunt", 0.1},
+            {"Piercing", 0.1}, // DS14-value
+            {"Blunt", 0.3},
         }
     };
 
@@ -113,7 +113,7 @@ public sealed partial class ZombieComponent : Component
         {
             { "Blunt", -0.4 },
             { "Slash", -0.2 },
-            { "Piercing", -0.2 },
+            { "Piercing", -0.4 }, // DS14-value
             { "Heat", -0.25 },
             { "Shock", -0.25 }
         }
@@ -135,7 +135,7 @@ public sealed partial class ZombieComponent : Component
         {
             { "Blunt", -8 },
             { "Slash", -8 },
-            { "Piercing", -8 },
+            { "Piercing", -12 }, // DS14-value
             { "Cold", -8 },
             { "Heat", -8 }
         }
@@ -150,7 +150,8 @@ public sealed partial class ZombieComponent : Component
         DamageDict = new()
         {
             { "Slash", 13 },
-            { "Piercing", 7 },
+            { "Piercing", 11 }, // DS14-value
+            { "Stamina", 25}, // DS14-value
             { "Structural", 10 }
         }
     };

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -425,14 +425,14 @@
   - type: GameRule
     minPlayers: 25 # DS14
     delay:
-      min: 600
-      max: 900
+      min: 60 # DS14
+      max: 90 # DS14
   - type: ZombieRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 6
+      max: 8 # DS14
       playerRatio: 10
       blacklist:
         components:
@@ -442,8 +442,7 @@
         text: zombie-patientzero-role-greeting
         color: Plum
         sound: "/Audio/Ambience/Antag/zombie_start.ogg"
-      components:
-      - type: PendingZombie
+      components: # DS14
       - type: ZombifyOnDeath
       - type: IncurableZombie
       - type: InitialInfected

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -166,6 +166,7 @@
     - JawsOfLife # DS14
     - WelderExperimental # DS14
     - SprayPainterRecharging # DS14
+    - DoorRemoteAll # DS14
 
 #Gladiator with spear
 - type: startingGear


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- Добавлено: Зомби не замедляются от урона. Супер пульт от шлюза в сумку агоста
- Удалено: Компонент убивающий нулевых
- Изменено: Характеристики зомби незначительно изменены. Нулевые теперь выдаются спустя 1 минуту, а не 10, в зомби-режиме. Максимальное число нулевых повышено до 8
- Исправлено: 
-->
