### PR TITLE
Хамелеонские хамелеочки

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -14,6 +14,14 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+// DS14-START
+using Content.Shared.Movement.Components;
+using Content.Shared.Radio.Components;
+using Content.Shared.Flash.Components;
+using Content.Shared.Damage.Components;
+using Content.Shared.DeadSpace.FakeDescription;
+using Content.Shared.Electrocution;
+// DS14-END
 
 namespace Content.Shared.Clothing.EntitySystems;
 
@@ -127,6 +135,66 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
         {
             RemComp<ContrabandComponent>(uid);
         }
+        // DS14-start
+        // footsteps sound
+        if (proto.TryGetComponent(out FootstepModifierComponent? footsteps, Factory))
+        {
+            EnsureComp<FootstepModifierComponent>(uid, out var current);
+            current.FootstepSoundCollection = footsteps.FootstepSoundCollection;
+        }
+        else
+        {
+            RemComp<FootstepModifierComponent>(uid);
+        }
+
+        // headset color
+        if (proto.TryGetComponent(out HeadsetComponent? radio, Factory))
+        {
+            EnsureComp<HeadsetComponent>(uid, out var current);
+            current.Color = radio.Color;
+        }
+
+        // glasses flash description
+        if (proto.TryGetComponent(out FlashImmunityComponent? glasses, Factory))
+        {
+            if (TryComp(uid, out FlashImmunityComponent? immunity))
+            {
+                immunity.ShowInExamine = glasses.ShowInExamine;
+            }
+            else
+            {
+                EnsureComp<FlashImmunityComponent>(uid, out var current);
+                current.ShowInExamine = glasses.ShowInExamine;
+                current.Enabled = false;
+            }
+        }
+        else
+        {
+            if (TryComp(uid, out FlashImmunityComponent? immunity))
+                immunity.ShowInExamine = false;
+        }
+
+        // fake slow on damage modifier
+        if (proto.TryGetComponent(out ClothingSlowOnDamageModifierComponent? boots, Factory))
+        {
+            EnsureComp<FakeClothingSlowOnDamageModifierComponent>(uid, out var current);
+            current.Modifier = boots.Modifier;
+        }
+        else
+        {
+            RemComp<FakeClothingSlowOnDamageModifierComponent>(uid);
+        }
+
+        // fake insulated
+        if (proto.TryGetComponent(out InsulatedComponent? imagineThatIsNull, Factory))
+        {
+            EnsureComp<FakeInsulatedComponent>(uid);
+        }
+        else
+        {
+            RemComp<FakeInsulatedComponent>(uid);
+        }
+        // DS14-end
     }
 
     private void OnVerb(Entity<ChameleonClothingComponent> ent, ref GetVerbsEvent<InteractionVerb> args)

--- a/Content.Shared/DeadSpace/FakeDescription/Components/FakeClothingSlowOnDamageModifierComponent.cs
+++ b/Content.Shared/DeadSpace/FakeDescription/Components/FakeClothingSlowOnDamageModifierComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.DeadSpace.FakeDescription;
+
+[RegisterComponent]
+public sealed partial class FakeClothingSlowOnDamageModifierComponent : Component
+{
+    [DataField]
+    public float Modifier = 1;
+}

--- a/Content.Shared/DeadSpace/FakeDescription/Components/FakeInsulatedComponent.cs
+++ b/Content.Shared/DeadSpace/FakeDescription/Components/FakeInsulatedComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.DeadSpace.FakeDescription;
+
+[RegisterComponent]
+public sealed partial class FakeInsulatedComponent : Component
+{
+    [DataField]
+    public bool Insulated = true;
+}

--- a/Content.Shared/DeadSpace/FakeDescription/FakeClothingSlowOnDamageModifierSystem.cs
+++ b/Content.Shared/DeadSpace/FakeDescription/FakeClothingSlowOnDamageModifierSystem.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Examine;
+
+namespace Content.Shared.DeadSpace.FakeDescription;
+
+public sealed class FakeClothingSlowOnDamageModifierSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FakeClothingSlowOnDamageModifierComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<FakeClothingSlowOnDamageModifierComponent> ent, ref ExaminedEvent args)
+    {
+        var msg = Loc.GetString("slow-on-damage-modifier-examine", ("mod", (1 - ent.Comp.Modifier) * 100));
+        args.PushMarkup(msg);
+    }
+}

--- a/Content.Shared/DeadSpace/FakeDescription/FakeInsulatedSystem.cs
+++ b/Content.Shared/DeadSpace/FakeDescription/FakeInsulatedSystem.cs
@@ -1,31 +1,21 @@
-using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.Verbs;
 
-namespace Content.Shared.Electrocution;
+namespace Content.Shared.DeadSpace.FakeDescription;
 
-public sealed class InsulatedSystem : EntitySystem
+public sealed class FakeInsulatedSystem : EntitySystem
 {
     [Dependency] private readonly ExamineSystemShared _examine = default!;
 
-    /// <inheritdoc />
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<InsulatedComponent, GetVerbsEvent<ExamineVerb>>(OnDetailedExamine);
+        SubscribeLocalEvent<FakeInsulatedComponent, GetVerbsEvent<ExamineVerb>>(OnDetailedExamine);
     }
 
-    private void OnDetailedExamine(EntityUid ent, InsulatedComponent component, ref GetVerbsEvent<ExamineVerb> args)
+    private void OnDetailedExamine(EntityUid ent, FakeInsulatedComponent component, ref GetVerbsEvent<ExamineVerb> args)
     {
-        if (!HasComp<ClothingComponent>(ent))
-            return;
-
-        // DS14-start
-        if (!component.ShowInExamine)
-            return;
-        // DS14-end
-
         var iconTexture = "/Textures/Interface/VerbIcons/zap.svg.192dpi.png";
 
         _examine.AddHoverExamineVerb(args,

--- a/Content.Shared/Electrocution/InsulatedComponent.cs
+++ b/Content.Shared/Electrocution/InsulatedComponent.cs
@@ -13,5 +13,10 @@ namespace Content.Shared.Electrocution
         /// </summary>
         [DataField, AutoNetworkedField]
         public float Coefficient { get; set; } = 0f;
+
+        // DS14-start
+        [DataField, AutoNetworkedField]
+        public bool ShowInExamine = true;
+        // DS14-end
     }
 }

--- a/Content.Shared/Flash/Components/FlashImmunityComponent.cs
+++ b/Content.Shared/Flash/Components/FlashImmunityComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Flash.Components;
 /// When given to clothes in the "head", "eyes" or "mask" slot it protects the wearer.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedFlashSystem))]
+// [Access(typeof(SharedFlashSystem))] #DS14
 public sealed partial class FlashImmunityComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Radio/Components/HeadsetComponent.cs
+++ b/Content.Shared/Radio/Components/HeadsetComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class HeadsetComponent : Component
 
     // DS14-start
     [DataField]
-    public Color Color { get; private set; } = Color.Lime;
+    public Color Color = Color.Lime;
 
     [DataField]
     public SoundSpecifier RadioReceiveSoundPath = new SoundPathSpecifier("/Audio/_DeadSpace/Items/Misc/radio_headset_receive.ogg");


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->
N/A

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
N/A

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- Изменено: Обувь с хамелеоном теперь издаёт звуки соответствующие тому под что замаскирована, если у оригинала имеется снижение замедления от урона, у хамелеона появится фейковое описание об этом. Гарнитура с хамелеоном теперь имеет цвет рации соответствующий тому под какую замаскирована. Очки с хамелеоном при осмотре показывают защиту от вспышек только если оригинал имеет защиту от вспышек, сама же защита хоть и не показывается при осмотре никуда не пропадает. Перчатки с хамелеоном показывают фейковую иконку изолированности если такая есть у оригинала.
