### PR TITLE
SGFix | Теперь фонарик на SG не пустое обещание.

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DeadSpace/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -365,3 +365,10 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: UnpoweredFlashlight
+  - type: PointLight
+    enabled: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    autoRot: true
+    radius: 6
+    netsync: false


### PR DESCRIPTION
## Ссылка на задачу
```py
None
```
## Медиа
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d56be37e-bb59-4512-bcea-7b0dfdcc054e" />

## Требования
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
```py
None
```
**Список изменений**
:cl: CatBackG
- Исправлено: Теперь SG-336 имеет фонарик на деле, а не на бумаге.

