### PR TITLE
Зомби: Тихий час

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -473,8 +473,8 @@
   - type: GameRule
     minPlayers: 25 # DS14
     delay:
-      min: 60 # DS14
-      max: 90 # DS14
+      min: 600 # DS14
+      max: 900 # DS14
   - type: ZombieRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn


### PR DESCRIPTION
:cl:
- Изменено: Минимальное время распределения зомби в соответствующий режим увеличено до 10 минут, максимальное до 15 минут.