### PR TITLE
Дредноут: ЧЁРТОВЫ СТУЛЬЯ АААААА

### DIFF
--- a/Content.Server/DeadSpace/RoundEnd/RoundEndManifestStatsSystem.cs
+++ b/Content.Server/DeadSpace/RoundEnd/RoundEndManifestStatsSystem.cs
@@ -285,8 +285,9 @@ public sealed class RoundEndManifestStatsSystem : EntitySystem
         if (_frozenDisplaySnapshots.Contains(mindId))
             return;
 
-        // Entity and map teardown can detach minds after a bulk-delete command has captured its entity list.
-        if (TerminatingOrDeleted(source) ||
+        // Mind, entity, and map teardown can detach minds after a bulk-delete command has captured its entity list.
+        if (TerminatingOrDeleted(mindId) ||
+            TerminatingOrDeleted(source) ||
             !TryComp(source, out TransformComponent? transform) ||
             transform.MapUid is not { } mapUid ||
             TerminatingOrDeleted(mapUid))

--- a/Content.Server/DeadSpace/TheCircle/Dreadnought/DreadnoughtLastStandSystem.cs
+++ b/Content.Server/DeadSpace/TheCircle/Dreadnought/DreadnoughtLastStandSystem.cs
@@ -14,6 +14,8 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Stunnable;
+using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
@@ -23,7 +25,7 @@ namespace Content.Server.DeadSpace.TheCircle.Dreadnought;
 public sealed class DreadnoughtLastStandSystem : EntitySystem
 {
     private const string OuterClothingSlot = "outerClothing";
-    private readonly HashSet<EntityUid> _pendingStrapDestruction = [];
+    private readonly Dictionary<EntityUid, (EntityUid Wearer, TimeSpan StunDuration)> _pendingStrapDestruction = [];
 
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -32,6 +34,7 @@ public sealed class DreadnoughtLastStandSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _thresholds = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -52,12 +55,12 @@ public sealed class DreadnoughtLastStandSystem : EntitySystem
     {
         var wearer = args.Buckle.Owner;
         if (!_inventory.TryGetSlotEntity(wearer, OuterClothingSlot, out var outerClothing) ||
-            !HasComp<DreadnoughtLastStandComponent>(outerClothing.Value))
+            !TryComp<DreadnoughtLastStandComponent>(outerClothing.Value, out var dreadnought))
             return;
 
         // Buckle() still validates its parent relationship after this event.
         // Destroy the strap on the following update, once buckling has completed.
-        _pendingStrapDestruction.Add(ent.Owner);
+        _pendingStrapDestruction[ent.Owner] = (wearer, dreadnought.StrapBreakStunDuration);
     }
 
     private void OnGetActions(Entity<DreadnoughtLastStandComponent> ent, ref GetItemActionsEvent args)
@@ -105,7 +108,7 @@ public sealed class DreadnoughtLastStandSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        foreach (var strap in _pendingStrapDestruction)
+        foreach (var (strap, pending) in _pendingStrapDestruction)
         {
             if (Deleted(strap))
                 continue;
@@ -114,6 +117,7 @@ public sealed class DreadnoughtLastStandSystem : EntitySystem
             _audio.PlayPvs(new SoundCollectionSpecifier("MetalBreak"), strap);
             Spawn("SheetSteel1", coordinates);
             _destructible.DestroyEntity(strap);
+            _stun.TryUpdateParalyzeDuration(pending.Wearer, pending.StunDuration);
         }
         _pendingStrapDestruction.Clear();
 
@@ -125,6 +129,7 @@ public sealed class DreadnoughtLastStandSystem : EntitySystem
 
             component.Expired = true;
             Dirty(uid, component);
+            EnsureComp<UnrevivableComponent>(uid);
             _mobState.UpdateMobState(uid);
         }
     }

--- a/Content.Shared/DeadSpace/TheCircle/Dreadnought/DreadnoughtBuckleSystem.cs
+++ b/Content.Shared/DeadSpace/TheCircle/Dreadnought/DreadnoughtBuckleSystem.cs
@@ -1,0 +1,82 @@
+// Мёртвый Космос, Licensed under custom terms with restrictions on public hosting and commercial use, full text: https://raw.githubusercontent.com/dead-space-server/space-station-14-fobos/master/LICENSE.TXT
+
+using Content.Shared.Buckle;
+using Content.Shared.Buckle.Components;
+using Content.Shared.DoAfter;
+using Content.Shared.Inventory;
+
+namespace Content.Shared.DeadSpace.TheCircle.Dreadnought;
+
+public sealed class DreadnoughtBuckleSystem : EntitySystem
+{
+    private const string OuterClothingSlot = "outerClothing";
+    private readonly HashSet<(EntityUid Buckle, EntityUid Strap)> _completedBuckleAttempts = [];
+
+    [Dependency] private readonly SharedBuckleSystem _buckle = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StrapComponent, StrapAttemptEvent>(OnStrapAttempt);
+        SubscribeLocalEvent<StrapComponent, DreadnoughtBuckleDoAfterEvent>(OnBuckleDoAfter);
+    }
+
+    private void OnStrapAttempt(Entity<StrapComponent> ent, ref StrapAttemptEvent args)
+    {
+        if (args.Cancelled || args.User != args.Buckle.Owner)
+            return;
+
+        var wearer = args.Buckle.Owner;
+        var attempt = (wearer, ent.Owner);
+        if (_completedBuckleAttempts.Contains(attempt))
+            return;
+
+        if (!_inventory.TryGetSlotEntity(wearer, OuterClothingSlot, out var outerClothing) ||
+            !TryComp<DreadnoughtLastStandComponent>(outerClothing.Value, out var dreadnought) ||
+            dreadnought.BuckleDelay <= TimeSpan.Zero)
+            return;
+
+        args.Cancelled = true;
+        var doAfter = new DoAfterArgs(
+            EntityManager,
+            wearer,
+            dreadnought.BuckleDelay,
+            new DreadnoughtBuckleDoAfterEvent(),
+            ent.Owner,
+            target: wearer,
+            used: ent.Owner)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            DuplicateCondition = DuplicateConditions.SameEvent,
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnBuckleDoAfter(Entity<StrapComponent> ent, ref DreadnoughtBuckleDoAfterEvent args)
+    {
+        if (args.Cancelled ||
+            args.Handled ||
+            args.Target is not { } wearer ||
+            args.User != wearer ||
+            args.Used != ent.Owner ||
+            !_inventory.TryGetSlotEntity(wearer, OuterClothingSlot, out var outerClothing) ||
+            !HasComp<DreadnoughtLastStandComponent>(outerClothing.Value))
+            return;
+
+        var attempt = (wearer, ent.Owner);
+        _completedBuckleAttempts.Add(attempt);
+        try
+        {
+            args.Handled = _buckle.TryBuckle(wearer, wearer, ent.Owner, popup: false);
+        }
+        finally
+        {
+            _completedBuckleAttempts.Remove(attempt);
+        }
+    }
+}

--- a/Content.Shared/DeadSpace/TheCircle/Dreadnought/DreadnoughtLastStandComponent.cs
+++ b/Content.Shared/DeadSpace/TheCircle/Dreadnought/DreadnoughtLastStandComponent.cs
@@ -1,9 +1,11 @@
 // Мёртвый Космос, Licensed under custom terms with restrictions on public hosting and commercial use, full text: https://raw.githubusercontent.com/dead-space-server/space-station-14-fobos/master/LICENSE.TXT
 
 using Content.Shared.Actions;
+using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.DeadSpace.TheCircle.Dreadnought;
 
@@ -24,6 +26,12 @@ public sealed partial class DreadnoughtLastStandComponent : Component
 
     [DataField]
     public float DeathDamage = 165f;
+
+    [DataField]
+    public TimeSpan BuckleDelay = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public TimeSpan StrapBreakStunDuration = TimeSpan.FromSeconds(3);
 
     [DataField]
     public SlotFlags RequiredSlots = SlotFlags.OUTERCLOTHING;
@@ -52,3 +60,6 @@ public sealed partial class DreadnoughtLastStandActiveComponent : Component
 }
 
 public sealed partial class DreadnoughtLastStandActionEvent : InstantActionEvent;
+
+[Serializable, NetSerializable]
+public sealed partial class DreadnoughtBuckleDoAfterEvent : SimpleDoAfterEvent;


### PR DESCRIPTION
:cl:
- Добавлено: Дредноут теперь залезает на стулья в течение 1-ой секунды, после чего тот ломает стул и ложится в стан на 3 секунды.
- Добавлено: После смерти дредноута из-за эффекта "Последнего рубежа" игроку выдаётся черта "нереанимируемого". 