### PR TITLE
Нерф щитов

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -127,10 +127,14 @@
         coefficients:
           Blunt: 0.7
           Slash: 0.7
+          Piercing: 1.1 #DS14
+          Heat: 1.2 #DS14
       activeBlockModifier:
         coefficients:
           Blunt: 0.5
           Slash: 0.5
+          Piercing: 0.9 #DS14
+          Heat: 1 #DS14
         flatReductions:
           Blunt: 1
           Slash: 1
@@ -144,6 +148,9 @@
             Blunt: 110
       staminaDamage: 60
       staminaDamageToUser: 30   
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
     #DS14-End
 
 - type: entity
@@ -166,12 +173,19 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
+          Piercing: 1.5 #DS14
           Heat: 0.7
       activeBlockModifier:
         coefficients:
+          Piercing: 1.3 #DS14
           Heat: 0.5
         flatReductions:
           Heat: 1
+    #DS14-Start
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
+    #DS14-End
 
 - type: entity
   name: ballistic shield
@@ -194,9 +208,11 @@
       passiveBlockModifier:
         coefficients:
           Piercing: 0.7
+          Heat: 1.5 #DS14
       activeBlockModifier:
         coefficients:
           Piercing: 0.5
+          Heat: 1.3 #DS14
         flatReductions:
           Piercing: 1
     #DS14-Start
@@ -209,6 +225,9 @@
             Blunt: 110
       staminaDamage: 60
       staminaDamageToUser: 30   
+    - type: ClothingSpeedModifier
+      walkModifier: 0.9
+      sprintModifier: 0.9
     #DS14-End
 
 #Craftable shields
@@ -786,7 +805,7 @@
 #              acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
-            damage: 180
+            damage: 130 #DS14
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- Добавлено: 
- Удалено: 
- Изменено: 
- Исправлено: 
-->
:cl:
- Добавлено: Замедление в 10% баллистическому, противолазерному и противоударному щитам.
- Изменено: Баллистический щит теперь получает 150% термического урона в руке и 130% термического урона в поднятом состоянии.
- Изменено: Противолазерный щит теперь получает 150% колющего урона в руке и 130% колющего урона в поднятом состоянии.
- Изменено: Противоударный щит теперь получает 120% термического урона и 110% колющего урона в руке, в поднятом состоянии 100% урона и 90% урона соответственно.
- Изменено: Телескопический щит снизил свою прочность до 130.