### PR TITLE
Ксенофобия у Синдиката, изменение спавнера

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -429,7 +429,7 @@
     - type: Loadout
       prototypes: [ VisitorPsychologist, VisitorPsychologistAlt ]
       roleLoadout: [ RoleSurvivalMedical ]
-    - type: GhostRoleNotifys #DS14 
+    - type: GhostRoleNotifys #DS14
       groupPrototype: VisitorGroup
 
 - type: randomHumanoidSettings
@@ -571,7 +571,7 @@
     - type: Loadout
       prototypes: [ VisitorBoxer, VisitorBoxerAlt ]
       roleLoadout: [ RoleSurvivalStandard ]
-    - type: GhostRoleNotifys #DS14 
+    - type: GhostRoleNotifys #DS14
       groupPrototype: VisitorGroup
 
 - type: randomHumanoidSettings
@@ -1090,6 +1090,25 @@
       roleLoadout: [ RoleSurvivalSyndicate ]
     - type: GhostRoleNotifys #DS14
       groupPrototype: OperativeGroup
+# DS14-start
+  speciesBlacklist:
+    # - Arachnid
+    - Diona
+    # - Dwarf
+    # - Human
+    # - Moth
+    # - Reptilian
+    # - SlimePerson
+    - Vox
+    # - Demon
+    # - Shark
+    # - Tajaran
+    # - Vulpkanin
+    # - Felinid
+    # - Kobolt
+    # - Xenomorph
+    - IPC
+# DS14-end
 
 - type: randomHumanoidSettings
   id: SyndieSoldier
@@ -1121,6 +1140,25 @@
       roleLoadout: [ RoleSurvivalSyndicate ]
     - type: GhostRoleNotifys #DS14
       groupPrototype: OperativeGroup
+# DS14-start
+  speciesBlacklist:
+    # - Arachnid
+    - Diona
+    # - Dwarf
+    # - Human
+    # - Moth
+    # - Reptilian
+    # - SlimePerson
+    - Vox
+    # - Demon
+    # - Shark
+    # - Tajaran
+    # - Vulpkanin
+    # - Felinid
+    # - Kobolt
+    # - Xenomorph
+    - IPC
+# DS14-end
 
 - type: randomHumanoidSettings
   id: SyndieVisitor


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
https://discord.com/channels/1030160796401016883/1537790276322594817/1537790276322594817

## Медиа
не

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [x] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
При добавлением в раунд геймрула UnknownShuttleSyndieEvacPod 3 солдата синдиката отныне генерируются без расы Дион,КПБ,Вокс.
:cl:
- Изменено: При ивенте неизвестного шаттла, на эвакуационном поде синдиката отныне не спавнятся Дионы,КПБ,Воксы.
